### PR TITLE
update a lot of stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ https://developer.valvesoftware.com/wiki/SteamCMD#Linux
 
 We assume you have created the `steam` user to store steamcmd and your ARK server.
 
+## Install requirement
+Use this command to install soft requirement on your system
+```
+apt-get install screen unzip
+```
+
 ## Install ARK Server Tools
 
 To install ARK Server Tools run these commands:
@@ -55,6 +61,9 @@ manually updates ARK server
 
 #### arkmanager status
 Get the status of the server. Show if the process is running, if the server is up and the current version number
+
+#### arkmanager checkupdate
+Check if a new version of the server is available but not apply it
 
 #### arkmanager broadcast [message]
 broadcast a message to ARK server chat

--- a/README.md
+++ b/README.md
@@ -8,10 +8,24 @@ https://developer.valvesoftware.com/wiki/SteamCMD#Linux
 
 We assume you have created the `steam` user to store steamcmd and your ARK server.
 
-## Install requirement
+## Requirements
 Use this command to install soft requirement on your system
 ```
 apt-get install screen unzip
+```
+
+Edit /etc/sysctl.conf and set:
+```
+fs.file-max=100000
+```
+Edit /etc/security/limits.conf and set these limits:
+```
+* soft nofile 100000
+* hard nofile 100000
+```
+Add the following line to /etc/pam.d/common-session:
+```
+session required pam_limits.so
 ```
 
 ## Install ARK Server Tools

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ NB: You may want to change the `install.sh` parameter to fit your steam user if 
 
 This will copy the `arkmanager` and the `arkdaemon` to the proper directories and will create an empty log directory in `/var/log` for ARK Server Tools.
 
+## Configure ARK Server
+
+All the needed variables are stored in the /etc/arkmanager/arkmanager.cfg configuration file change them following the comments.
+
 ## Install ARK Server
 
 To install ARK Server just run this command as normal user:
@@ -32,11 +36,6 @@ To install ARK Server just run this command as normal user:
 ```sh
 arkmanager install
 ```
-
-## Configure ARK Server
-
-All the needed variables are stored in the `steam` home directory inside `.arkmanager.cfg`, change them following the comments.
-
 ## Commands
 
 #### arkmanager install
@@ -53,6 +52,9 @@ restarts ARK server
 
 #### arkmanager update
 manually updates ARK server
+
+#### arkmanager status
+Get the status of the server. Show if the process is running, if the server is up and the current version number
 
 #### arkmanager broadcast [message]
 broadcast a message to ARK server chat

--- a/tools/arkdaemon
+++ b/tools/arkdaemon
@@ -1,4 +1,13 @@
-#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          ARK manager deamon
+# Required-Start:    networking
+# Required-Stop:     networking
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: ARK manager deamon
+# Description:       Automaticaly start ARK server
+#
+### END INIT INFO
 
 # Global variables
 source /etc/arkdaemon.cfg

--- a/tools/arkdaemon
+++ b/tools/arkdaemon
@@ -60,9 +60,9 @@ case "$1" in
   ;;
 
   *)
-    N=/etc/init.d/$NAME
-    echo "Usage: $N {start|stop|restart|force-reload}" >&2
-    exit 1
+    # For invalid arguments, print the usage message.
+    echo "Usage: $0 {start|stop|restart|status|force-reload}"
+    exit 2
   ;;
 esac
 

--- a/tools/arkdaemon
+++ b/tools/arkdaemon
@@ -5,9 +5,12 @@
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: ARK manager deamon
-# Description:       Automaticaly start ARK server
+# Description:       ARK manager daemon used to start the server and keep it updated
 #
 ### END INIT INFO
+
+# Using the lsb functions to perform the operations.
+. /lib/lsb/init-functions
 
 # Global variables
 source /etc/arkdaemon.cfg
@@ -17,33 +20,45 @@ NAME=arkmanager_daemon
 DESC="ARK manager daemon used to start the server and keep it updated"
 PIDFILE="/var/run/${NAME}.pid"
 LOGFILE="${logdir}/${NAME}.log"
-
-
-DAEMON="sh /usr/bin/arkmanager update"
-
+DAEMON="arkmanager"
 START_OPTS="--pidfile ${PIDFILE} --user=${steamuser} ${DAEMON}"
 
 set -e
 
+# If the daemon is not there, then exit.
+test -x $DAEMON || exit 5
+
 case "$1" in
   start)
-    echo -n "Starting ${DESC}: "
-    daemon $START_OPTS >> $LOGFILE
-    echo "$NAME."
+    log_daemon_msg "Starting" "$NAME"
+    if start-stop-daemon -b --start --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON ; then
+      log_end_msg 0
+    else
+      log_end_msg 1
+    fi
   ;;
+
   stop)
-    echo -n "Stopping $DESC: "
+    log_daemon_msg "Stopping" "$NAME"
     kill ${cat $PIDFILE}
     echo "$NAME."
     rm -f $PIDFILE
   ;;
+
   restart|force-reload)
-    echo -n "Restarting $DESC: "
-    kill $(cat $PIDFILE)
-    sleep 1
-    daemon $START_OPTS >> $LOGFILE
-    echo "$NAME."
+    $0 stop && sleep 2 && $0 start
   ;;
+
+  status)
+    # Check the status of the process.
+    PID=`ps -ef | grep $DAEMON | grep -v grep | awk '{print $2}'`
+    if  [ -n "$PID" ];  then
+      echo "$NAME is running on PID $PID"
+    else
+  	echo "$NAME is not running"
+    fi
+  ;;
+
   *)
     N=/etc/init.d/$NAME
     echo "Usage: $N {start|stop|restart|force-reload}" >&2

--- a/tools/arkdaemon.cfg
+++ b/tools/arkdaemon.cfg
@@ -1,2 +1,0 @@
-# user of your steamcmd and ARK server instance (don't use root!)
-steamuser=

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -29,19 +29,32 @@ NORMAL="\\033[0;39m"
 #---------------------
 # functions
 #---------------------
+function checkForUpdate(){
+  if isUpdateNeeded; then
+    echo "Current version:" $instver
+    echo "Available version:" $bnumber
+    echo "Your server needs to be restarted in order to receive the latest update."
+    echo "Run \"arkmanager update\" to do so"
+  else
+    echo "No update available"
+  fi
+}
+function setCurrentVersion(){
+  # set the new current version in a file
+  cd $arkserverroot
+  echo $bnumber > arkversion
+}
 function isUpdateNeeded(){
   #
   # Check if the server need to be updated
-  # Return 1 if update is needed, else return 0
+  # Return 0 if update is needed, else return 1
   #
   getCurrentVersion
   getAvailableVersion
-  echo $instver
-  echo $bnumber
-  if ["$bnumber" = "$instver"]; then
-      return 0
+  if [ "$bnumber" -eq "$instver" ]; then
+    return 1   # no update needed
   else
-      return 1
+    return 0   # update needed
   fi
 
 }
@@ -59,9 +72,8 @@ function getAvailableVersion(){
   #
   # Get the current available server version on steamdb
   #
-  echo "Checking for update, this may take a while"
   bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_print "$appid" +quit | grep -EA 5 "^\s+\"public\"$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -f3 | sed 's/^ //' | cut -c9-14`
-  echo "Available server version: "$bnumber
+  return $bnumber
 }
 
 function isTheServerRunning(){
@@ -92,6 +104,7 @@ case "$1" in
     restart);;
     install);;
     update);;
+    checkupdate);;
     broadcast);;
     status);;
     *)
@@ -108,52 +121,60 @@ doStart() {
     echo "$timestamp: start" >> "$logdir/arkserver.log"
 }
 
-# stop function
+
 doStop() {
-    read -p "This operation will quit the server without saving, are your really sure?" -n 1 -r
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        screen -S "$servicename" -p 0 -X stuff "quit$(printf \\r)"
-        # screen -S "$servicename" -X quit
-        sleep 30
-        echo "$timestamp: stop" >> "$logdir/arkserver.log"
-    fi
+  #
+  # stop the ARK server
+  #
+  screen -S "$servicename" -p 0 -X stuff "quit$(printf \\r)"
+  # screen -S "$servicename" -X quit
+  sleep 30
+  echo "$timestamp: stop" >> "$logdir/arkserver.log"
+
 }
 
-# install function
 doInstall() {
-    if [ ! -d "$arkserverroot" ]; then
-        mkdir $arkserverroot
-    fi
-    cd $steamcmdroot
-    ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
+  #
+  # install of ARK server
+  #
+  if [ ! -d "$arkserverroot" ]; then
+      mkdir $arkserverroot
+  fi
+  cd $steamcmdroot
+  # install the server
+  ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
+  # the current version should be the last version. We set our version
+  getAvailableVersion
+  setCurrentVersion
 }
 
-# update function
 doUpdate() {
-    cd $arkserverroot
-    if isUpdateNeeded; then
-        if [ -f "$arkserverroot/arkupdate.timed" ]
-            then
-                doStop
-                cd $steamcmdroot
-                ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
-                cd $logdir
-                echo "$bnumber" > "$arkserverroot/arkversion"
-                cd $steamcmdroot
-                doStart
-                echo "$timestamp: update to $bnumber complete" >> "$logdir/update.log"
-                if [ $servermail != "" ]; then
-                  mail -a $logdir/update.log -s "Update-Log" $servermail < /dev/null
-                fi
-                rm "$arkserverroot/arkupdate.timed"
-            else
-                touch "$arkserverroot/arkupdate.timed"
-                info="There is a update for ark, server will restart in 60mins!!!!!"
-                doInfo $info
-        fi;
-    else
-        echo "$timestamp: No update needed." >> "$logdir/update.log"
-    fi;
+  #
+  # Stop the server, update it and then start it back.
+  #
+  cd $arkserverroot
+  if isUpdateNeeded; then
+      if [ -f "$arkserverroot/arkupdate.timed" ]; then
+              doStop
+              cd $steamcmdroot
+              ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
+              cd $logdir
+              echo "$bnumber" > "$arkserverroot/arkversion"
+              cd $steamcmdroot
+              doStart
+              echo "$timestamp: update to $bnumber complete" >> "$logdir/update.log"
+              if [ $servermail != "" ]; then
+                mail -a $logdir/update.log -s "Update-Log" $servermail < /dev/null
+              fi
+              rm "$arkserverroot/arkupdate.timed"
+          else
+              touch "$arkserverroot/arkupdate.timed"
+              info="There is a update for ark, server will restart in 60mins!!!!!"
+              doInfo $info
+      fi;
+  else
+      echo "$timestamp: No update needed." >> "$logdir/update.log"
+  fi;
 }
 
 #broadcast info
@@ -203,7 +224,11 @@ case "$1" in
         doInstall
     ;;
     update)
-        doUpdate
+        testupdate
+        #doUpdate
+    ;;
+    checkupdate)
+      checkForUpdate
     ;;
     broadcast)
         doInfo $2

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -84,7 +84,7 @@ esac
 
 # start function
 doStart() {
-    arkserveropts="TheIsland?QueryPort=$arkserverport?ServerPassword=$arkserverpass?ServerAdminPassword=$arkserverapass?listen"
+    arkserveropts="TheIsland?QueryPort=$arkqueryport?Port=$arkserverport?ServerPassword=$arkserverpass?ServerAdminPassword=$arkserverapass?listen"
     thejob="$arkserverroot/$arkserverexec $arkserveropts"
     screen -dmS "$servicename" $thejob
     echo "$timestamp: start" >> "$logdir/arkserver.log"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -27,7 +27,17 @@ NORMAL="\\033[0;39m"
 #---------------------
 # functions
 #---------------------
-function getServerVersion(){
+function getCurrentVersion(){
+  #
+  # Return the current version number
+  #
+  cd $arkserverroot
+  touch arkversion # If the file doesn't exist
+  instver=`cat "arkversion"`
+  return $instver
+
+}
+function getAvailableVersion(){
   #
   # Get the current available server version on steamdb
   #
@@ -67,7 +77,7 @@ case "$1" in
     broadcast);;
     status);;
     *)
-        echo "use arkmanager <start|stop|restart|install|update|broadcast>"
+        echo "use arkmanager <start|stop|restart|install|update|broadcast|status>"
         exit 0
     ;;
 esac
@@ -144,6 +154,23 @@ doInfo() {
 	screen -S "$servicename" -p 0 -X stuff "broadcast $info $(printf \\r)"
 }
 
+printStatus(){
+  if isTheServerRunning ;then
+    echo -e "$NORMAL" "Server running:" "$GREEN" "Yes"
+  else
+    echo -e "$NORMAL" "Server running:" "$RED" "No"
+  fi
+
+  if IsTheServerUp ;then
+    echo -e "$NORMAL" "Server online:" "$GREEN" " Yes"
+  else
+    echo -e "$NORMAL" "Server online:" "$RED" " No"
+  fi
+  getCurrentVersion
+  echo -e "$NORMAL" "Server version:" "$GREEN" $instver
+
+}
+
 #---------------------
 # Main program
 #---------------------
@@ -172,18 +199,7 @@ case "$1" in
         doInfo $2
     ;;
     status)
-      if isTheServerRunning ;then
-        echo -e "$NORMAL" "Server running:" "$GREEN" "Yes"
-      else
-        echo -e "$NORMAL" "Server running:" "$RED" "No"
-      fi
-
-      if IsTheServerUp ;then
-        echo -e "$NORMAL" "Server online:" "$GREEN" " Yes"
-      else
-        echo -e "$NORMAL" "Server online:" "$RED" " No"
-      fi
-      #getServerVersion
+      printStatus
     ;;
     *)
         echo "use arkmanager <start|stop|restart|install|update|broadcast|status>"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -19,6 +19,8 @@ source /etc/arkmanager/arkmanager.cfg
 # Local variables
 info=""
 thejob=""
+instver=""
+bnumber=""
 timestamp=$( date +%T )
 GREEN="\\033[1;32m"
 RED="\\033[1;31m"
@@ -27,6 +29,22 @@ NORMAL="\\033[0;39m"
 #---------------------
 # functions
 #---------------------
+function isUpdateNeeded(){
+  #
+  # Check if the server need to be updated
+  # Return 1 if update is needed, else return 0
+  #
+  getCurrentVersion
+  getAvailableVersion
+  echo $instver
+  echo $bnumber
+  if ["$bnumber" = "$instver"]; then
+      return 0
+  else
+      return 1
+  fi
+
+}
 function getCurrentVersion(){
   #
   # Return the current version number
@@ -113,15 +131,7 @@ doInstall() {
 # update function
 doUpdate() {
     cd $arkserverroot
-    touch arkversion # If the file doesn't exist
-    instver=`cat "arkversion"`
-    bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_print "$appid" +quit | grep -EA 5 "^\s+\"public\"$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -f3 | sed 's/^ //' | cut -c9-14`
-    if ["$bnumber" = "$instver"]; then
-        patch=0
-    fi
-
-    if (($patch == 1))
-    then
+    if isUpdateNeeded; then
         if [ -f "$arkserverroot/arkupdate.timed" ]
             then
                 doStop

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -108,19 +108,20 @@ case "$1" in
     broadcast);;
     status);;
     *)
-        echo "use arkmanager <start|stop|restart|install|update|broadcast|status>"
+        echo "use arkmanager <start|stop|restart|install|update|broadcast|status|checkupdate>"
         exit 0
     ;;
 esac
 
-# start function
 doStart() {
-    arkserveropts="TheIsland?QueryPort=$arkqueryport?Port=$arkserverport?ServerPassword=$arkserverpass?ServerAdminPassword=$arkserverapass?listen"
-    thejob="$arkserverroot/$arkserverexec $arkserveropts"
-    screen -dmS "$servicename" $thejob
-    echo "$timestamp: start" >> "$logdir/arkserver.log"
+  #
+  # start function
+  #
+  arkserveropts="TheIsland?QueryPort=$arkqueryport?Port=$arkserverport?ServerPassword=$arkserverpass?ServerAdminPassword=$arkserverapass?listen"
+  thejob="$arkserverroot/$arkserverexec $arkserveropts"
+  screen -dmS "$servicename" $thejob
+  echo "$timestamp: start" >> "$logdir/arkserver.log"
 }
-
 
 doStop() {
   #
@@ -154,25 +155,21 @@ doUpdate() {
   #
   cd $arkserverroot
   if isUpdateNeeded; then
-      if [ -f "$arkserverroot/arkupdate.timed" ]; then
-              doStop
-              cd $steamcmdroot
-              ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
-              cd $logdir
-              echo "$bnumber" > "$arkserverroot/arkversion"
-              cd $steamcmdroot
-              doStart
-              echo "$timestamp: update to $bnumber complete" >> "$logdir/update.log"
-              if [ $servermail != "" ]; then
-                mail -a $logdir/update.log -s "Update-Log" $servermail < /dev/null
-              fi
-              rm "$arkserverroot/arkupdate.timed"
-          else
-              touch "$arkserverroot/arkupdate.timed"
-              info="There is a update for ark, server will restart in 60mins!!!!!"
-              doInfo $info
-      fi;
+      doStop
+      cd $steamcmdroot
+      ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid +quit
+      cd $logdir
+      echo "$bnumber" > "$arkserverroot/arkversion"
+      cd $steamcmdroot
+      doStart
+      echo "$timestamp: update to $bnumber complete" >> "$logdir/update.log"
+      if [ $servermail -ne "" ]; then
+        mail -a $logdir/update.log -s "Update-Log" $servermail < /dev/null
+      fi
+      rm "$arkserverroot/arkupdate.timed"
+
   else
+      echo "No update available"
       echo "$timestamp: No update needed." >> "$logdir/update.log"
   fi;
 }
@@ -224,8 +221,7 @@ case "$1" in
         doInstall
     ;;
     update)
-        testupdate
-        #doUpdate
+        doUpdate
     ;;
     checkupdate)
       checkForUpdate

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -29,7 +29,16 @@ NORMAL="\\033[0;39m"
 #---------------------
 # functions
 #---------------------
+function testfunction(){
+  if [ -z $servermail ]; then
+    echo "mail ok"
+  fi
+
+}
 function checkForUpdate(){
+  #
+  # Check if a new version is available but not apply it
+  #
   if isUpdateNeeded; then
     echo "Current version:" $instver
     echo "Available version:" $bnumber
@@ -40,7 +49,9 @@ function checkForUpdate(){
   fi
 }
 function setCurrentVersion(){
+  #
   # set the new current version in a file
+  #
   cd $arkserverroot
   echo $bnumber > arkversion
 }
@@ -81,7 +92,7 @@ function isTheServerRunning(){
   # Check id the server process is alive
   #
   SERVICE="ShooterGameServer"
-  ps -a | grep -v grep | grep $SERVICE > /dev/null
+  ps aux | grep -v grep | grep $SERVICE > /dev/null
   result=$?
   return $result
 }
@@ -91,7 +102,7 @@ function IsTheServerUp(){
   # Check if the server is up and visible in steam server list
   # If the server is listenning on his port return 0, else return 1
   #
-  PORT="7776"
+  PORT="7779"
   lsof -i |grep $PORT > /dev/null
   result=$?
   return $result
@@ -117,21 +128,27 @@ doStart() {
   #
   # start function
   #
-  arkserveropts="TheIsland?QueryPort=$arkqueryport?Port=$arkserverport?ServerPassword=$arkserverpass?ServerAdminPassword=$arkserverapass?listen"
-  thejob="$arkserverroot/$arkserverexec $arkserveropts"
-  screen -dmS "$servicename" $thejob
-  echo "$timestamp: start" >> "$logdir/arkserver.log"
+  if isTheServerRunning; then
+    echo "The server is already running"
+  else
+    arkserveropts="TheIsland?SessionName=$sessioname?QueryPort=$arkqueryport?Port=$arkserverport?ServerPassword=$arkserverpass?ServerAdminPassword=$arkserverapass?listen"
+    thejob="$arkserverroot/$arkserverexec $arkserveropts"
+    screen -dmS "$servicename" $thejob
+    echo "$timestamp: start" >> "$logdir/arkserver.log"
+  fi
 }
 
 doStop() {
   #
   # stop the ARK server
   #
-  screen -S "$servicename" -p 0 -X stuff "quit$(printf \\r)"
-  # screen -S "$servicename" -X quit
-  sleep 30
-  echo "$timestamp: stop" >> "$logdir/arkserver.log"
-
+  if isTheServerRunning; then
+    screen -X -S "$servicename" -X stuff "^C"
+    sleep 30
+    echo "$timestamp: stop" >> "$logdir/arkserver.log"
+  else
+    echo "The server is already stopped"
+  fi
 }
 
 doInstall() {
@@ -154,20 +171,29 @@ doUpdate() {
   # Stop the server, update it and then start it back.
   #
   cd $arkserverroot
-  if isUpdateNeeded; then
-      doStop
-      cd $steamcmdroot
-      ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid +quit
-      cd $logdir
-      echo "$bnumber" > "$arkserverroot/arkversion"
-      cd $steamcmdroot
-      doStart
-      echo "$timestamp: update to $bnumber complete" >> "$logdir/update.log"
-      if [ $servermail -ne "" ]; then
-        mail -a $logdir/update.log -s "Update-Log" $servermail < /dev/null
-      fi
-      rm "$arkserverroot/arkupdate.timed"
 
+  if isUpdateNeeded; then
+    # check if the server was alive before the update so we can launch it back after the update
+    serverWasAlive=0
+    if isTheServerRunning ;then
+      serverWasAlive=1
+    fi
+    doStop
+    cd $steamcmdroot
+    ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid +quit
+    cd $logdir
+    echo "$bnumber" > "$arkserverroot/arkversion"
+    cd $steamcmdroot
+    echo "$timestamp: update to $bnumber complete" >> "$logdir/update.log"
+
+    # we restart the server only if it was started before the update
+    if [ $serverWasAlive -eq 1 ]; then
+      doStart
+    fi
+    # send mail to admin
+    #if [ -z $servermail ]; then
+    #  mail -a $logdir/update.log -s "Update-Log" $servermail < /dev/null
+    #fi
   else
       echo "No update available"
       echo "$timestamp: No update needed." >> "$logdir/update.log"
@@ -212,7 +238,7 @@ case "$1" in
     restart)
         doStop
         echo "$timestamp: stop" >> "$logdir/arkserver.log"
-        sleep 60
+        sleep 10
         doStart
         echo "$timestamp: start" >> "$logdir/arkserver.log"
         echo "$timestamp: restart" >> "$logdir/arkserver.log"
@@ -222,6 +248,7 @@ case "$1" in
     ;;
     update)
         doUpdate
+        #testfunction
     ;;
     checkupdate)
       checkForUpdate

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -3,12 +3,59 @@
 # ARK: survival evolved manager
 #
 # Original author:      LeXaT
-# Maintainer:           FezVrasta
+# Maintainer:           FezVrasta, Sispheor
 
+# Check the user is not currently running this script as root
 if [ "$(id -u)" == "0" ]; then
    echo "This script must NOT be run as root" 1>&2
    exit 1
 fi
+
+#---------------------
+# Variables
+#---------------------
+# Global variables
+source /etc/arkmanager/arkmanager.cfg
+# Local variables
+info=""
+thejob=""
+timestamp=$( date +%T )
+GREEN="\\033[1;32m"
+RED="\\033[1;31m"
+NORMAL="\\033[0;39m"
+
+#---------------------
+# functions
+#---------------------
+function getServerVersion(){
+  #
+  # Get the current available server version on steamdb
+  #
+  echo "Checking for update, this may take a while"
+  bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_print "$appid" +quit | grep -EA 5 "^\s+\"public\"$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -f3 | sed 's/^ //' | cut -c9-14`
+  echo "Available server version: "$bnumber
+}
+
+function isTheServerRunning(){
+  #
+  # Check id the server process is alive
+  #
+  SERVICE="ShooterGameServer"
+  ps -a | grep -v grep | grep $SERVICE > /dev/null
+  result=$?
+  return $result
+}
+
+function IsTheServerUp(){
+  #
+  # Check if the server is up and visible in steam server list
+  # If the server is listenning on his port return 0, else return 1
+  #
+  PORT="7776"
+  lsof -i |grep $PORT > /dev/null
+  result=$?
+  return $result
+}
 
 # To speedup stuff, if you have not specified a command or the command is invalid, we skip everything and just give you the usage message
 case "$1" in
@@ -18,32 +65,12 @@ case "$1" in
     install);;
     update);;
     broadcast);;
+    status);;
     *)
         echo "use arkmanager <start|stop|restart|install|update|broadcast>"
         exit 0
     ;;
 esac
-
-# Global variables
-source ~/.arkmanager.cfg
-
-# init
-if [ ! -d "$arkserverroot" ]; then
-    mkdir $arkserverroot
-fi
-
-info=""
-thejob=""
-patch=1
-timestamp=$( date +%T )
-cd $arkserverroot
-touch arkversion # If the file doesn't exist
-instver=`cat "arkversion"`
-bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_print "$appid" +quit | grep -EA 5 "^\s+\"public\"$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -f3 | sed 's/^ //' | cut -c9-14`
-
-if ["$bnumber" = "$instver"]; then
-    patch=0
-fi
 
 # start function
 doStart() {
@@ -66,25 +93,38 @@ doStop() {
 
 # install function
 doInstall() {
+    if [ ! -d "$arkserverroot" ]; then
+        mkdir $arkserverroot
+    fi
     cd $steamcmdroot
-    ./$steamcmdexec +login $steamuser $steampass +force_install_dir "$arkserverroot" +app_update $appid validate +quit
+    ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
 }
 
 # update function
 doUpdate() {
+    cd $arkserverroot
+    touch arkversion # If the file doesn't exist
+    instver=`cat "arkversion"`
+    bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_print "$appid" +quit | grep -EA 5 "^\s+\"public\"$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -f3 | sed 's/^ //' | cut -c9-14`
+    if ["$bnumber" = "$instver"]; then
+        patch=0
+    fi
+
     if (($patch == 1))
     then
         if [ -f "$arkserverroot/arkupdate.timed" ]
             then
                 doStop
                 cd $steamcmdroot
-                ./$steamcmdexec +login $steamuser $steampass +force_install_dir "$arkserverroot" +app_update $appid validate +quit
+                ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
                 cd $logdir
                 echo "$bnumber" > "$arkserverroot/arkversion"
                 cd $steamcmdroot
                 doStart
                 echo "$timestamp: update to $bnumber complete" >> "$logdir/update.log"
-                mail -a $logdir/update.log -s "Update-Log" $servermail < /dev/null
+                if [ $servermail != "" ]; then
+                  mail -a $logdir/update.log -s "Update-Log" $servermail < /dev/null
+                fi
                 rm "$arkserverroot/arkupdate.timed"
             else
                 touch "$arkserverroot/arkupdate.timed"
@@ -104,7 +144,9 @@ doInfo() {
 	screen -S "$servicename" -p 0 -X stuff "broadcast $info $(printf \\r)"
 }
 
-# parameter select
+#---------------------
+# Main program
+#---------------------
 case "$1" in
     start)
         doStart
@@ -129,7 +171,21 @@ case "$1" in
     broadcast)
         doInfo $2
     ;;
+    status)
+      if isTheServerRunning ;then
+        echo -e "$NORMAL" "Server running:" "$GREEN" "Yes"
+      else
+        echo -e "$NORMAL" "Server running:" "$RED" "No"
+      fi
+
+      if IsTheServerUp ;then
+        echo -e "$NORMAL" "Server online:" "$GREEN" " Yes"
+      else
+        echo -e "$NORMAL" "Server online:" "$RED" " No"
+      fi
+      #getServerVersion
+    ;;
     *)
-        echo "use arkmanager <start|stop|restart|install|update|broadcast>"
+        echo "use arkmanager <start|stop|restart|install|update|broadcast|status>"
     ;;
 esac

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -1,8 +1,6 @@
 # config SteamCMD
 steamcmdroot="/home/steam/steamcmd"                                 # path of your steamcmd instance
 steamcmdexec="steamcmd.sh"                                          # name of steamcmd executable
-steamuser="USERNAME"                                                # steam user (needed to download the app, anonymous is not allowed)
-steampass="PASSWORD"                                                # steam password
 
 # config Server
 arkserverroot="/home/steam/ARK"                                     # path of your ARK server files (default ~/ARK)
@@ -15,5 +13,9 @@ arkserverapass="ADMINPASSWORD"                                      # ARK server
 servicename="arkserv"                                               # Name of the service (don't change if you don't know what are you doing)
 logdir="/var/log/arktools"                                          # Logs path (default /var/log/arktools)
 
+# steamdb specific
 appid=376030                                                        # Linux server App ID
+
+# admin information
+notify_update_by_email=0                                            # if you want to receive a mail on each update (SMTP client must be configured)
 servermail=mail@domain.com                                          # Log email

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -4,10 +4,11 @@ steamcmdexec="steamcmd.sh"                                          # name of st
 steamcmd_user="steam"                                               # name of the system user who own steamcmd folder
 
 # config Server
+sessioname=YourLinuxSessionName
 arkserverroot="/home/steam/ARK"                                     # path of your ARK server files (default ~/ARK)
 arkserverexec="ShooterGame/Binaries/Linux/ShooterGameServer"        # name of ARK server executable
 arkqueryport="27016"                                                # ARK query port (default 27016)
-arkserverport="7778"                                                # ARK server port (default 7778)
+arkserverport="7779"                                                # ARK server port (default 7779)
 arkserverpass="SERVERPASSWORD"                                      # ARK server password, empty: no password required to login
 arkserverapass="ADMINPASSWORD"                                      # ARK server admin password, KEEP IT SAFE!
 

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -1,6 +1,7 @@
 # config SteamCMD
 steamcmdroot="/home/steam/steamcmd"                                 # path of your steamcmd instance
 steamcmdexec="steamcmd.sh"                                          # name of steamcmd executable
+steamcmd_user="steam"                                               # name of the system user who own steamcmd folder
 
 # config Server
 arkserverroot="/home/steam/ARK"                                     # path of your ARK server files (default ~/ARK)

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -6,7 +6,8 @@ steamcmd_user="steam"                                               # name of th
 # config Server
 arkserverroot="/home/steam/ARK"                                     # path of your ARK server files (default ~/ARK)
 arkserverexec="ShooterGame/Binaries/Linux/ShooterGameServer"        # name of ARK server executable
-arkserverport="27016"                                               # ARK server port (default 27016)
+arkqueryport="27016"                                                # ARK query port (default 27016)
+arkserverport="7778"                                                # ARK server port (default 7778)
 arkserverpass="SERVERPASSWORD"                                      # ARK server password, empty: no password required to login
 arkserverapass="ADMINPASSWORD"                                      # ARK server admin password, KEEP IT SAFE!
 

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -18,5 +18,4 @@ logdir="/var/log/arktools"                                          # Logs path 
 appid=376030                                                        # Linux server App ID
 
 # admin information
-notify_update_by_email=0                                            # if you want to receive a mail on each update (SMTP client must be configured)
-servermail=mail@domain.com                                          # Log email
+servermail=""                                                       # Log email, leave blank if you dont want to receive mail

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -13,17 +13,14 @@ if [ ! -z $1 ]; then
     mkdir -p /var/log/arktools
     chown $1 /var/log/arktools
 
-    # Copy .arkmanager.cfg inside user home
-    mv arkmanager.cfg /home/$1/.arkmanager.cfg
-    chown $1 /home/$1/.arkmanager.cfg
-
-    # Copy arkdaemon.cfg inside /etc folder
-    mv arkdaemon.cfg /etc/arkdaemon.cfg
-    chown $1 /etc/arkdaemon.cfg
-    echo ${1} >> /etc/arkdaemon.cfg
+    # Copy arkmanager.cfg inside linux configuation folder
+    mkdir /etc/arkmanager
+    mv arkmanager.cfg /etc/arkmanager/arkmanager.cfg
+    chown $1 /etc/arkmanager/arkmanager.cfg    
 
 else
-    echo "You must specify your steam user to install ARK Tools. Usage: ./install.sh steam"
+    echo "You must specify your system steam user who own steamcmd directory to install ARK Tools."
+    echo "Usage: ./install.sh steam"
 fi
 
 exit 0


### PR DESCRIPTION
What did I do?

- add requiered LSB tag to the init script
- init script now start the server by default (usefull if you reboot)
- add function to check the status: check if the server is running, if the port is listenning and the current version number
- add a function to check if an update is available. I removed it from the begining of the script to not run it if not necessary
- remove steam login and password. Login anonymous availlable now
- remove broadcast info. Because the server does not automaticaly restart in 60 minutes. We should wait for rcon to do that with crontab
- remove confirmation question when we stop. Because we can't use the script to do automatic update with cron
- add some comments
- update readme with new function. Ask the user to configure arkmanager before run the installation
- add check update function. just look for available update but not apply it
- remove validate from update function in order to apply it faster
- add required soft unzip and screen to readme installation
- check if the server is not already stopped before try to stop it, same for start function
- only restart the server if it was up before the update
- add file limit Requirements to the readme
- add sessionname and game port to the configuration file

