### PR TITLE
Dev#1.1 - config and distro compatibility

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -56,7 +56,7 @@ function checkForUpdate(){
 # Set the new current version in a file
 #
 function setCurrentVersion(){
-  cd $arkserverroot
+  cd "$arkserverroot"
   echo $bnumber > arkversion
 }
 
@@ -79,7 +79,7 @@ function isUpdateNeeded(){
 # Return the current version number
 #
 function getCurrentVersion(){
-  cd $arkserverroot
+  cd "$arkserverroot"
   touch arkversion # If the file doesn't exist
   instver=`cat "arkversion"`
   return $instver
@@ -123,9 +123,8 @@ doStart() {
     echo "The server is already running"
   else
     arkserveropts="TheIsland?SessionName=$sessioname?QueryPort=$arkqueryport?ServerPassword=$arkserverpass?ServerAdminPassword=$arkserverapass?listen"
-    thejob="$arkserverroot/$arkserverexec $arkserveropts"
     # run the server in background
-    $thejob >/dev/null 2>&1 &
+    nohup "$arkserverroot/$arkserverexec" "$arkserveropts" </dev/null >/dev/null 2>&1 &
     echo "$timestamp: start" >> "$logdir/arkserver.log"
   fi
 }
@@ -149,20 +148,20 @@ doStop() {
 # install of ARK server
 #
 doInstall() {
-  mkdir -p $arkserverroot
+  mkdir -p "$arkserverroot"
 
   # Check if steamcmd is installed, and if not, install it
-  if [ ! -e $steamcmdroot/$steamcmdexec ]; then
-    mkdir -p $steamcmdroot
+  if [ ! -e "$steamcmdroot/$steamcmdexec" ]; then
+    mkdir -p "$steamcmdroot"
     cd /tmp
     wget http://media.steampowered.com/installer/steamcmd_linux.tar.gz
-    tar -xvzf steamcmd_linux.tar.gz -C $steamcmdroot
-    cd $steamcmdroot
+    tar -xvzf steamcmd_linux.tar.gz -C "$steamcmdroot"
+    cd "$steamcmdroot"
     ./steamcmd.sh +quit
     echo "SteamCMD was installed in $steamcmdroot"
   fi
 
-  cd $steamcmdroot
+  cd "$steamcmdroot"
   # install the server
   ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
   # the current version should be the last version. We set our version
@@ -174,7 +173,7 @@ doInstall() {
 # Stop the server, update it and then start it back.
 #
 doUpdate() {
-  cd $arkserverroot
+  cd "$arkserverroot"
 
   if isUpdateNeeded; then
     # check if the server was alive before the update so we can launch it back after the update
@@ -183,11 +182,9 @@ doUpdate() {
       serverWasAlive=1
     fi
     doStop
-    cd $steamcmdroot
+    cd "$steamcmdroot"
     ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid +quit
-    cd $logdir
     echo "$bnumber" > "$arkserverroot/arkversion"
-    cd $steamcmdroot
     echo "$timestamp: update to $bnumber complete" >> "$logdir/update.log"
     tail -n 1 "$logdir/arkserver.log"
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -16,7 +16,13 @@ fi
 #---------------------
 
 # Global variables
-source /etc/arkmanager/arkmanager.cfg
+if [ -f "/etc/arkmanager/arkmanager.cfg" ]; then
+    source /etc/arkmanager/arkmanager.cfg
+fi
+
+if [ -f "${HOME}/.arkmanager.cfg" ]; then
+    source "${HOME}/.arkmanager.cfg"
+fi
 
 # Local variables
 info=""

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -129,6 +129,7 @@ doStart() {
     echo "The server is already running"
   else
     ark_SessionName="${ark_SessionName:-${sessionname}}"
+    ark_Port="${ark_Port:-${arkserverport}}"
     ark_QueryPort="${ark_QueryPort:-${arkqueryport}}"
     ark_ServerPassword="${ark_ServerPassword:-${arkserverpass}}"
     ark_ServerAdminPassword="${ark_ServerAdminPassword:-${arkserverapass}}"
@@ -138,6 +139,13 @@ doStart() {
     for varname in "${!ark_@}"; do
       name="${varname#ark_}"
       val="${!varname}"
+
+      # Port is actually one higher than specified
+      # i.e. specifying port 7777 will have the server
+      # use port 7778
+      if [ "$name" == "Port" ]; then
+        (( val = val - 1 ))
+      fi
 
       if [ -n "$val" ]; then
         arkserveropts="${arkserveropts}?${name}=${val}"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -128,7 +128,23 @@ doStart() {
   if isTheServerRunning; then
     echo "The server is already running"
   else
-    arkserveropts="TheIsland?SessionName=$sessioname?QueryPort=$arkqueryport?ServerPassword=$arkserverpass?ServerAdminPassword=$arkserverapass?listen"
+    ark_SessionName="${ark_SessionName:-${sessionname}}"
+    ark_QueryPort="${ark_QueryPort:-${arkqueryport}}"
+    ark_ServerPassword="${ark_ServerPassword:-${arkserverpass}}"
+    ark_ServerAdminPassword="${ark_ServerAdminPassword:-${arkserverapass}}"
+    arkserveropts="TheIsland"
+
+    # bring in ark_... options
+    for varname in "${!ark_@}"; do
+      name="${varname#ark_}"
+      val="${!varname}"
+
+      if [ -n "$val" ]; then
+        arkserveropts="${arkserveropts}?${name}=${val}"
+      fi
+    done
+
+    arkserveropts="${arkserveropts}?listen"
     # run the server in background
     nohup "$arkserverroot/$arkserverexec" "$arkserveropts" </dev/null >/dev/null 2>&1 &
     echo "$timestamp: start" >> "$logdir/arkserver.log"

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -12,6 +12,9 @@ arkserverport="7778"                                                # ARK server
 arkserverpass="SERVERPASSWORD"                                      # ARK server password, empty: no password required to login
 arkserverapass="ADMINPASSWORD"                                      # ARK server admin password, KEEP IT SAFE!
 
+# other options - use ark_<optionname>=<value>
+ark_MaxPlayers="70"
+
 # config Service
 servicename="arkserv"                                               # Name of the service (don't change if you don't know what are you doing)
 logdir="/var/log/arktools"                                          # Logs path (default /var/log/arktools)

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,32 +1,34 @@
 #!/bin/bash
 
-if [ ! -z $1 ]; then
+EXECPREFIX="${EXECPREFIX:-/usr/local}"
+
+if [ ! -z "$1" ]; then
     # Copy arkmanager to /usr/bin and set permissions
-    cp arkmanager /usr/bin/arkmanager
-    chmod +x /usr/bin/arkmanager
+    cp arkmanager "${INSTALL_ROOT}${EXECPREFIX}/bin/arkmanager"
+    chmod +x "${INSTALL_ROOT}${EXECPREFIX}/bin/arkmanager"
 
     # Copy arkdaemon to /etc/init.d ,set permissions and add it to boot
-    cp arkdaemon /etc/init.d/arkdaemon
-    chmod +x /etc/init.d/arkdaemon
+    cp arkdaemon "${INSTALL_ROOT}/etc/init.d/arkdaemon"
+    chmod +x "${INSTALL_ROOT}/etc/init.d/arkdaemon"
     # add to startup if the system use sysinit
-    if [ test -x /usr/sbin/update-rc.d ]; then
+    if [ -x /usr/sbin/update-rc.d -a -z "${INSTALL_ROOT}" ]; then
       update-rc.d arkdaemon defaults
       echo "Ark server will now start on boot, if you want to remove this feature run the following line"
       echo "update-rc.d -f arkdaemon remove"
     fi
 
     # Create a folder in /var/log to let Ark tools write its own log files
-    mkdir -p /var/log/arktools
-    chown $1 /var/log/arktools
+    mkdir -p "${INSTALL_ROOT}/var/log/arktools"
+    chown "$1" "${INSTALL_ROOT}/var/log/arktools"
 
     # Copy arkmanager.cfg inside linux configuation folder if it doesn't already exists
-    mkdir -p /etc/arkmanager
-    if [ -f /etc/arkmanager/arkmanager.cfg ]; then
+    mkdir -p "${INSTALL_ROOT}/etc/arkmanager"
+    if [ -f "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg" ]; then
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it.";
       exit 2
     else
-      cp -n arkmanager.cfg /etc/arkmanager/arkmanager.cfg
-      chown $1 /etc/arkmanager/arkmanager.cfg
+      cp -n arkmanager.cfg "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
+      chown "$1" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
     fi
 
 else


### PR DESCRIPTION
EXECPREFIX and INSTALL_ROOT can be used by distributions for packaging and to put the script where they want to put it (e.g. /usr, /usr/games, /usr/local, /opt/arkmanager)

Paths should also be quoted as they may contain spaces.

This also imports the user config into arkmanager - e.g. if a beefy host houses multiple game servers.  If run from the init script, it should source the config from the same file as the init script sources it from.

The custom server variables allow the definition of custom server variables - though most of the variables should be specified in the ShooterGame/Saved/Config/LinuxServer/GameUserSettings.ini file anyway.

I have re-added the Port option.  The port opened by the server is one higher than that specified in the options, so this corrects for that.