### PR TITLE
Dev#1.1 - fixes

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -141,9 +141,11 @@ function isTheServerRunning(){
 # Check if the server is down and not visible in steam server list
 #
 function isTheServerDown(){
-  lsof -i |grep $ark_Port > /dev/null
-  result=$?
-  return $result
+  if netstat -an | grep -q ":${ark_Port}\s"; then
+    return 1
+  else
+    return 0
+  fi
 }
 
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -177,7 +177,8 @@ doStart() {
 
     arkserveropts="${arkserveropts}?listen"
     # run the server in background
-    nohup "$arkserverroot/$arkserverexec" "$arkserveropts" </dev/null >/dev/null 2>&1 &
+    echo "--- $timestamp: starting server ---" >>"$logdir/server.log"
+    nohup "$arkserverroot/$arkserverexec" "$arkserveropts" </dev/null >>"$logdir/server.log" 2>&1 &
     echo "$timestamp: start" >> "$logdir/arkserver.log"
   fi
 }
@@ -192,7 +193,7 @@ doStop() {
     # kill the server with the PID
     PID=`ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'`
     kill -9 $PID
-    
+    echo "--- $timestamp: server stopped ---" >>"$logdir/server.log"
     tput rc; tput ed;
     echo "$timestamp: stop" >> "$logdir/arkserver.log"
   else

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -97,10 +97,34 @@ function getCurrentVersion(){
 }
 
 #
+# Parse the buildid from steamcmd
+#
+function parseSteamAppVer(){
+  local sname
+  while read name val; do
+    name="${name#\"}"
+    name="${name%\"}"
+    val="${val#\"}"
+    val="${val%\"}"
+    if [ "$name" = "}" ]; then
+      break
+    elif [ "$name" == "{" ]; then
+      parseSteamAppVer "${1}.${sname}"
+    else
+      if [ "$1" == ".depots.branches.public" -a "$name" == "buildid" ]; then
+        echo "$val"
+        break
+      fi
+      sname="${name}"
+    fi
+  done
+}
+
+#
 # Get the current available server version on steamdb
 #
 function getAvailableVersion(){
-  bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_print "$appid" +quit | grep -EA 5 "^\s+\"public\"$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -f3 | sed 's/^ //' | cut -c9-14`
+  bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_print "$appid" +quit | while read name val; do if [ "${name}" == "{" ]; then parseSteamAppVer; break; fi; done`
   return $bnumber
 }
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -191,8 +191,7 @@ doStop() {
     tput sc
     echo "Stopping server..."
     # kill the server with the PID
-    PID=`ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'`
-    kill -9 $PID
+    killall -9 "$arkserverroot/$arkserverexec"
     echo "--- $timestamp: server stopped ---" >>"$logdir/server.log"
     tput rc; tput ed;
     echo "$timestamp: stop" >> "$logdir/arkserver.log"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -132,8 +132,7 @@ function getAvailableVersion(){
 # Check id the server process is alive
 #
 function isTheServerRunning(){
-  SERVICE="ShooterGameServer"
-  ps aux | grep -v grep | grep $SERVICE > /dev/null
+  pidof "$arkserverroot/$arkserverexec" >/dev/null
   result=$?
   return $result
 }

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -50,6 +50,7 @@ if [ ! -z "$1" ]; then
     else
       cp -n arkmanager.cfg "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
       chown "$1" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
+      sed -i "s|^steamcmd_user=\"steam\"|steamcmd_user=\"$1\"|;s|\"/home/steam|\"/home/$1|" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
     fi
 
 else

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -21,7 +21,7 @@ if [ ! -z "$1" ]; then
     elif [ -f /etc/rc.d/init.d/functions ]; then
       cp redhat/arkdaemon "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
       chmod +x "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
-      sed -i "s@^DAEMON=\"/usr/bin@DAEMON=\"${EXECPREFIX}@" "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
+      sed -i "s@^DAEMON=\"/usr@DAEMON=\"${EXECPREFIX}@" "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
       if [ -x /sbin/chkconfig -a -z "${INSTALL_ROOT}" ]; then
         chkconfig --add arkmanager
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"
@@ -30,7 +30,7 @@ if [ ! -z "$1" ]; then
     elif [ -f /sbin/runscript ]; then
       cp openrc/arkdaemon "${INSTALL_ROOT}/etc/init.d/arkmanager"
       chmod +x "${INSTALL_ROOT}/etc/init.d/arkmanager"
-      sed -i "s@^DAEMON=\"/usr/bin@DAEMON=\"${EXECPREFIX}@" "${INSTALL_ROOT}/etc/init.d/arkmanager"
+      sed -i "s@^DAEMON=\"/usr@DAEMON=\"${EXECPREFIX}@" "${INSTALL_ROOT}/etc/init.d/arkmanager"
       if [ -x /sbin/rc-update -a -z "${INSTALL_ROOT}" ]; then
         rc-update add arkmanager default
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"


### PR DESCRIPTION
The first patch of this series parses the output of app_info_print (which is line-based, similar in structure to json, and easily parsed by bash) and extracts the buildid of the public branch.

I then use pidof instead of ps/grep to match on executable name

Many distributions don't have lsof installed by default, so I have replaced that with netstat.

I have added server output logging.  Unfortunately this won't show if the server aborted or segfaulted.

Instead of grabbing the PID of the process using ps and grep and killing the resulting PID, this uses killall to kill the process by executable path.

I found a typo I made in the path modification for the init scripts, so I have fixed that.

The install script now also modifies the new config file to match the requested install user.