### PR TITLE
Dev#1.1 - fixes

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -97,10 +97,34 @@ function getCurrentVersion(){
 }
 
 #
+# Parse the buildid from steamcmd
+#
+function parseSteamAppVer(){
+  local sname
+  while read name val; do
+    name="${name#\"}"
+    name="${name%\"}"
+    val="${val#\"}"
+    val="${val%\"}"
+    if [ "$name" = "}" ]; then
+      break
+    elif [ "$name" == "{" ]; then
+      parseSteamAppVer "${1}.${sname}"
+    else
+      if [ "$1" == ".depots.branches.public" -a "$name" == "buildid" ]; then
+        echo "$val"
+        break
+      fi
+      sname="${name}"
+    fi
+  done
+}
+
+#
 # Get the current available server version on steamdb
 #
 function getAvailableVersion(){
-  bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_print "$appid" +quit | grep -EA 5 "^\s+\"public\"$" | grep -E "^\s+\"buildid\"\s+" | tr '[:blank:]"' ' ' | tr -s ' ' | cut -f3 | sed 's/^ //' | cut -c9-14`
+  bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_print "$appid" +quit | while read name val; do if [ "${name}" == "{" ]; then parseSteamAppVer; break; fi; done`
   return $bnumber
 }
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -30,7 +30,7 @@ if [ ! -z "$1" ]; then
     elif [ -f /etc/rc.d/init.d/functions ]; then
       cp redhat/arkdaemon "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
       chmod +x "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
-      sed -i "s@^DAEMON=\"/usr/bin@DAEMON=\"${EXECPREFIX}@" "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
+      sed -i "s@^DAEMON=\"/usr@DAEMON=\"${EXECPREFIX}@" "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
       if [ -x /sbin/chkconfig -a -z "${INSTALL_ROOT}" ]; then
         chkconfig --add arkmanager
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"
@@ -39,7 +39,7 @@ if [ ! -z "$1" ]; then
     elif [ -f /sbin/runscript ]; then
       cp openrc/arkdaemon "${INSTALL_ROOT}/etc/init.d/arkmanager"
       chmod +x "${INSTALL_ROOT}/etc/init.d/arkmanager"
-      sed -i "s@^DAEMON=\"/usr/bin@DAEMON=\"${EXECPREFIX}@" "${INSTALL_ROOT}/etc/init.d/arkmanager"
+      sed -i "s@^DAEMON=\"/usr@DAEMON=\"${EXECPREFIX}@" "${INSTALL_ROOT}/etc/init.d/arkmanager"
       if [ -x /sbin/rc-update -a -z "${INSTALL_ROOT}" ]; then
         rc-update add arkmanager default
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -62,6 +62,7 @@ if [ ! -z "$1" ]; then
     else
       cp -n arkmanager.cfg "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
       chown "$1" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
+      sed -i "s|^steamcmd_user=\"steam\"|steamcmd_user=\"$1\"|;s|\"/home/steam|\"/home/$1|" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
     fi
 
 else


### PR DESCRIPTION
The first patch of this series parses the output of app_info_print (which is line-based, similar in structure to json, and easily parsed by bash) and extracts the buildid of the public branch.

I found a typo I made in the path modification for the init scripts, so I have fixed that.

The install script now also modifies the new config file to match the requested install user.