### PR TITLE
Dev#1.1 - systemd

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -15,7 +15,7 @@ if [ ! -z "$1" ]; then
         cp lsb/arkdaemon "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
         chmod +x "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
         cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-        sed -i "s|=\"/usr/|=\"${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        sed -i "s|=/usr/|=${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         if [ -z "${INSTALL_ROOT}" ]; then
           systemctl daemon-reload
           systemctl enable arkmanager.service
@@ -40,7 +40,7 @@ if [ ! -z "$1" ]; then
         cp redhat/arkdaemon "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
         chmod +x "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
         cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-        sed -i "s|=\"/usr/|=\"${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        sed -i "s|=/usr/|=${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         if [ -z "${INSTALL_ROOT}" ]; then
           systemctl daemon-reload
           systemctl enable arkmanager.service
@@ -71,7 +71,7 @@ if [ ! -z "$1" ]; then
       cp systemd/arkdaemon.init "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
       chmod +x "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
       cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-      sed -i "s|=\"/usr/|=\"${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+      sed -i "s|=/usr/|=${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
       if [ -z "${INSTALL_ROOT}" ]; then
         systemctl enable arkmanager.service
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -10,15 +10,18 @@ if [ ! -z "$1" ]; then
     # Copy arkdaemon to /etc/init.d ,set permissions and add it to boot
     if [ -f /lib/lsb/init-functions ]; then
       # on debian 8, sysvinit and systemd are present. If systemd is available we use it instead of sysvinit
-      if [[ -f /etc/systemd/system.conf ]]; then   # used by systemd
-        mkdir -p "/usr/libexec/arkmanager"
-        cp lsb/arkdaemon "/usr/libexec/arkmanager/arkmanager.init"
-        chmod +x "/usr/libexec/arkmanager/arkmanager.init"
-        cp systemd/arkdeamon.service /etc/systemd/system/arkmanager.service
-        systemctl daemon-reload
-        systemctl enable arkmanager.service
-        echo "Ark server will now start on boot, if you want to remove this feature run the following line"
-        echo "systemctl disable arkmanager.service"
+      if [ -f /etc/systemd/system.conf ]; then   # used by systemd
+        mkdir -p "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager"
+        cp lsb/arkdaemon "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+        chmod +x "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+        cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        sed -i "s|=\"/usr/|=\"${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        if [ -z "${INSTALL_ROOT}" ]; then
+          systemctl daemon-reload
+          systemctl enable arkmanager.service
+          echo "Ark server will now start on boot, if you want to remove this feature run the following line"
+          echo "systemctl disable arkmanager.service"
+	fi
       else  # systemd not present, so use sysvinit
         cp lsb/arkdaemon "${INSTALL_ROOT}/etc/init.d/arkmanager"
         chmod +x "${INSTALL_ROOT}/etc/init.d/arkmanager"
@@ -32,15 +35,18 @@ if [ ! -z "$1" ]; then
       fi
     elif [ -f /etc/rc.d/init.d/functions ]; then
       # on RHEL 7, sysvinit and systemd are present. If systemd is available we use it instead of sysvinit
-      if [[ -f /etc/systemd/system.conf ]]; then   # used by systemd
-        mkdir -p "/usr/libexec/arkmanager"
-        cp redhat/arkdaemon "/usr/libexec/arkmanager/arkmanager.init"
-        chmod +x "/usr/libexec/arkmanager/arkmanager.init"
-        cp systemd/arkdeamon.service /etc/systemd/system/arkmanager.service
-        systemctl daemon-reload
-        systemctl enable arkmanager.service
-        echo "Ark server will now start on boot, if you want to remove this feature run the following line"
-        echo "systemctl disable arkmanager.service"
+      if [ -f /etc/systemd/system.conf ]; then   # used by systemd
+        mkdir -p "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager"
+        cp redhat/arkdaemon "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+        chmod +x "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+        cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        sed -i "s|=\"/usr/|=\"${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        if [ -z "${INSTALL_ROOT}" ]; then
+          systemctl daemon-reload
+          systemctl enable arkmanager.service
+          echo "Ark server will now start on boot, if you want to remove this feature run the following line"
+          echo "systemctl disable arkmanager.service"
+        fi
       else # systemd not preset, so use sysvinit
         cp redhat/arkdaemon "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
         chmod +x "${INSTALL_ROOT}/etc/rc.d/init.d/arkmanager"
@@ -60,14 +66,17 @@ if [ ! -z "$1" ]; then
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"
         echo "rc-update del arkmanager default"
       fi
-    elif [[ /etc/systemd/system.conf ]]; then   # used by systemd
-      mkdir -p /usr/libexec/arkmanager
-      cp systemd/arkdaemon.init "/usr/libexec/arkmanager/arkmanager.init"
-      chmod +x "/usr/libexec/arkmanager/arkmanager.init"
-      cp systemd/arkdeamon.service /etc/systemd/system/arkmanager.service
-      systemctl enable arkmanager.service
-      echo "Ark server will now start on boot, if you want to remove this feature run the following line"
-      echo "systemctl disable arkmanager.service"
+    elif [ -f /etc/systemd/system.conf ]; then   # used by systemd
+      mkdir -p "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager"
+      cp systemd/arkdaemon.init "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+      chmod +x "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+      cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+      sed -i "s|=\"/usr/|=\"${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+      if [ -z "${INSTALL_ROOT}" ]; then
+        systemctl enable arkmanager.service
+        echo "Ark server will now start on boot, if you want to remove this feature run the following line"
+        echo "systemctl disable arkmanager.service"
+      fi
     fi
 
     # Create a folder in /var/log to let Ark tools write its own log files

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -14,9 +14,9 @@ if [ ! -z "$1" ]; then
         mkdir -p "/usr/libexec/arkmanager"
         cp lsb/arkdaemon "/usr/libexec/arkmanager/arkmanager.init"
         chmod +x "/usr/libexec/arkmanager/arkmanager.init"
-        cp systemd/arkdeamon.service /etc/systemd/system/arkdaemon.service
+        cp systemd/arkdeamon.service /etc/systemd/system/arkmanager.service
         systemctl daemon-reload
-        systemctl enable arkdaemon.service
+        systemctl enable arkmanager.service
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"
         echo "systemctl disable arkmanager.service"
       else  # systemd not present, so use sysvinit
@@ -49,8 +49,8 @@ if [ ! -z "$1" ]; then
         echo "rc-update del arkmanager default"
       fi
     elif [[ /etc/systemd/system.conf ]]; then   # used by systemd
-      cp systemd/arkdeamon.service /etc/systemd/system/arkdaemon.service
-      systemctl enable arkdeamon.service
+      cp systemd/arkdeamon.service /etc/systemd/system/arkmanager.service
+      systemctl enable arkmanager.service
     fi
 
     # Create a folder in /var/log to let Ark tools write its own log files

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -61,8 +61,13 @@ if [ ! -z "$1" ]; then
         echo "rc-update del arkmanager default"
       fi
     elif [[ /etc/systemd/system.conf ]]; then   # used by systemd
+      mkdir -p /usr/libexec/arkmanager
+      cp systemd/arkdaemon.init "/usr/libexec/arkmanager/arkmanager.init"
+      chmod +x "/usr/libexec/arkmanager/arkmanager.init"
       cp systemd/arkdeamon.service /etc/systemd/system/arkmanager.service
       systemctl enable arkmanager.service
+      echo "Ark server will now start on boot, if you want to remove this feature run the following line"
+      echo "systemctl disable arkmanager.service"
     fi
 
     # Create a folder in /var/log to let Ark tools write its own log files

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -11,11 +11,14 @@ if [ ! -z "$1" ]; then
     if [ -f /lib/lsb/init-functions ]; then
       # on debian 8, sysvinit and systemd are present. If systemd is available we use it instead of sysvinit
       if [[ -f /etc/systemd/system.conf ]]; then   # used by systemd
+        mkdir -p "/usr/libexec/arkmanager"
+        cp lsb/arkdaemon "/usr/libexec/arkmanager/arkmanager.init"
+        chmod +x "/usr/libexec/arkmanager/arkmanager.init"
         cp systemd/arkdeamon.service /etc/systemd/system/arkdaemon.service
         systemctl daemon-reload
-        systemctl enable arkdeamon.service
+        systemctl enable arkdaemon.service
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"
-        echo "systemctl disable unit"
+        echo "systemctl disable arkmanager.service"
       else  # systemd not present, so use sysvinit
         cp lsb/arkdaemon "${INSTALL_ROOT}/etc/init.d/arkmanager"
         chmod +x "${INSTALL_ROOT}/etc/init.d/arkmanager"

--- a/tools/lsb/arkdaemon
+++ b/tools/lsb/arkdaemon
@@ -32,6 +32,7 @@ case "$1" in
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
+      echo "$PID" >/var/run/arkmanager.pid
       log_end_msg 0
     else
       log_end_msg 1
@@ -46,6 +47,7 @@ case "$1" in
     if  [ -n "$PID" ];  then
       log_end_msg 1
     else
+      rm /var/run/arkmanager.pid
       log_end_msg 0
     fi
   ;;

--- a/tools/redhat/arkdaemon
+++ b/tools/redhat/arkdaemon
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# /etc/rc.d/init.d/arkdaemon
+# /etc/rc.d/init.d/arkmanager
 #
 # ARK manager daemon
 #
@@ -46,7 +46,8 @@ case "$1" in
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
-      touch /var/lock/subsys/arkdaemon
+      echo "${PID}" >/var/run/arkmanager.pid
+      touch /var/lock/subsys/arkmanager
       echo "[" "$GREEN" " OK " "$NORMAL" "]"
       exit 0
     else
@@ -65,7 +66,8 @@ case "$1" in
       exit 1
     else
       echo "[" "$GREEN" " OK " "$NORMAL" "]"
-      rm -f /var/lock/subsys/arkdaemon
+      rm -f /var/lock/subsys/arkmanager
+      rm -f /var/run/arkmanager.pid
       exit 0
     fi
   ;;

--- a/tools/systemd/arkdaemon.init
+++ b/tools/systemd/arkdaemon.init
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# /usr/libexec/arkmanager/arkmanager.init
+#
+# ARK manager daemon
+#
+# chkconfig: 2345 80 20
+# description: ARK manager daemon used to start the server and keep it updated
+# processname: ShooterGameServer
+# config: /etc/arkmanager/arkmanager.cfg
+
+### BEGIN INIT INFO
+# Provides:          ARK manager deamon
+# Required-Start:    networking
+# Required-Stop:     networking
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: ARK manager deamon
+# Description:       ARK manager daemon used to start the server and keep it updated
+#
+### END INIT INFO
+
+# Global variables
+source /etc/arkmanager/arkmanager.cfg
+
+NAME="ShooterGameServer"
+LOGFILE="${logdir}/${NAME}.log"
+DAEMON="/usr/bin/arkmanager"
+
+GREEN="\\033[1;32m"
+RED="\\033[1;31m"
+NORMAL="\\033[0;39m"
+
+set -e
+
+# If the daemon is not there, then exit.
+test -x $DAEMON || exit 5
+
+case "$1" in
+  start)
+    echo -n "Starting $NAME: "
+    su -s /bin/sh -c "$DAEMON start" $steamcmd_user > /dev/null
+    sleep 5
+    PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
+    if  [ -n "$PID" ];  then
+      echo "$PID" >/var/run/arkmanager.pid
+      echo "[" "$GREEN" " OK " "$NORMAL" "]"
+      exit 0
+    else
+      echo "[" "$RED" " FAILED " "$NORMAL" "]"
+      exit 1
+    fi
+  ;;
+
+  stop)
+    echo -n "Stopping $NAME: "
+    su -s /bin/sh -c "$DAEMON stop" $steamcmd_user > /dev/null
+    sleep 5
+    PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
+    if  [ -n "$PID" ];  then
+      echo "[" "$RED" " FAILED " "$NORMAL" "]"
+      exit 1
+    else
+      echo "[" "$GREEN" " OK " "$NORMAL" "]"
+      rm /var/run/arkmanager.pid
+      exit 0
+    fi
+  ;;
+
+  restart)
+    echo -n "Restarting $NAME: "
+    su -s /bin/sh -c "$DAEMON restart" $steamcmd_user > /dev/null
+    echo "OK"
+  ;;
+
+  status)
+    su -s /bin/sh -c "$DAEMON status" $steamcmd_user
+    exit 0
+  ;;
+
+  *)
+    # For invalid arguments, print the usage message.
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+  ;;
+esac

--- a/tools/systemd/arkdeamon.service
+++ b/tools/systemd/arkdeamon.service
@@ -3,8 +3,8 @@ Description=Daemon to start ark server
 After=network.target
 
 [Service]
-ExecStart=/etc/init.d/arkdaemon start
-ExecStop=/etc/init.d/arkdaemon stop
+ExecStart=/usr/libexec/arkmanager/arkmanager.init start
+ExecStop=/usr/libexec/arkmanager/arkmanager.init stop
 Type=forking
 
 [Install]

--- a/tools/systemd/arkdeamon.service
+++ b/tools/systemd/arkdeamon.service
@@ -6,6 +6,7 @@ After=network.target
 ExecStart=/usr/libexec/arkmanager/arkmanager.init start
 ExecStop=/usr/libexec/arkmanager/arkmanager.init stop
 Type=forking
+PIDFile=/var/run/arkmanager.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This adds the systemd unit file to redhat, and copies either a distribution-specific or distribution-agnostic init script to /usr/libexec/arkmanager

It renames arkdaemon.service to arkmanager.service to be in line with the other init scripts

It also uses the INSTALL_ROOT and EXECPREFIX variables to allow packaging and installing to custom prefixes.