### PR TITLE
1.2 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ ark_ServerPVE=False
 ark_DifficultyOffset=1
 ```
 
-Your session name may contain special characters (eg. `!![EU]!! Aw&some ARK`) which could break the startup command.  
-In this case you may want to comment out the `ark_SessionName` variable and define it inside your **GameUserSettings.ini** file.
+Your session name may not contain special characters (eg. `!![EU]!! Aw&some ARK`) as it could break the startup command.  
+In this case you may want to comment out the `ark_SessionName` variable and define it inside your **GameUserSettings.ini** file instead.
 
 You can override or add variables for a specific system user creating a file called `.arkmanager.cfg` in the home directory of the system user.
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -198,6 +198,38 @@ function isTheServerUp(){
 }
 
 #
+# run function
+#
+doRun() {
+  arkserveropts=$serverMap
+
+  # bring in ark_... options
+  for varname in "${!ark_@}"; do
+    name="${varname#ark_}"
+    val="${!varname}"
+
+    # Port is actually one higher than specified
+    # i.e. specifying port 7777 will have the server
+    # use port 7778
+    if [ "$name" == "Port" ]; then
+      (( val = val - 1 ))
+    fi
+
+    if [ -n "$val" ]; then
+      arkserveropts="${arkserveropts}?${name}=${val}"
+    fi
+  done
+
+  arkserveropts="${arkserveropts}?listen"
+  # run the server in background
+  echo "`timestamp`: start"
+  # set max open files limit before we start the server
+  ulimit -n $maxOpenFiles
+  "$arkserverroot/$arkserverexec" "$arkserveropts"
+  
+}
+
+#
 # start function
 #
 doStart() {
@@ -207,31 +239,7 @@ doStart() {
     tput sc
     echo "The server is starting..."
 
-    arkserveropts=$serverMap
-
-    # bring in ark_... options
-    for varname in "${!ark_@}"; do
-      name="${varname#ark_}"
-      val="${!varname}"
-
-      # Port is actually one higher than specified
-      # i.e. specifying port 7777 will have the server
-      # use port 7778
-      if [ "$name" == "Port" ]; then
-        (( val = val - 1 ))
-      fi
-
-      if [ -n "$val" ]; then
-        arkserveropts="${arkserveropts}?${name}=${val}"
-      fi
-    done
-
-    arkserveropts="${arkserveropts}?listen"
-    # run the server in background
-    echo "`timestamp`: start" >> "$logdir/$arkserverLog"
-    # set max open files limit before we start the server
-    ulimit -n $maxOpenFiles
-    nohup "$arkserverroot/$arkserverexec" "$arkserveropts" </dev/null >"$logdir/$arkserverLog" 2>&1 & # output of this command is logged
+    doRun </dev/null >>"$logdir/$arkserverLog" 2>&1 & # output of this command is logged
     echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
     tput rc; tput ed;
     echo "The server is now up"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -101,14 +101,6 @@ function checkForUpdate(){
 }
 
 #
-# Set the new current version in a file
-#
-function setCurrentVersion(){
-  cd "$arkserverroot"
-  echo $bnumber > arkversion
-}
-
-#
 # Check if the server need to be updated
 # Return 0 if update is needed, else return 1
 #
@@ -156,6 +148,7 @@ function parseSteamACF(){
 function getCurrentVersion(){
   if [ -f "${arkserverroot}/steamapps/appmanifest_${appid}.acf" ]; then
     instver=`while read name val; do if [ "${name}" == "{" ]; then parseSteamACF "" "buildid"; break; fi; done <"${arkserverroot}/steamapps/appmanifest_${appid}.acf"`
+    echo $instver > "$arkserverroot/arkversion"
   else
     instver=""
   fi
@@ -268,8 +261,7 @@ doInstall() {
   # install the server
   ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
   # the current version should be the last version. We set our version
-  getAvailableVersion
-  setCurrentVersion
+  getCurrentVersion
 }
 
 #
@@ -296,8 +288,7 @@ forceUpdate(){
   cd "$steamcmdroot"
   ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid +quit
   # the current version should be the last version. We set our version
-  getAvailableVersion
-  setCurrentVersion
+  getCurrentVersion
   echo "$timestamp: update to $instver complete" >> "$logdir/update.log"
 
   # we restart the server only if it was started before the update

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -30,7 +30,6 @@ info=""
 thejob=""
 instver=""
 bnumber=""
-timestamp=$( date +%T )
 GREEN="\\033[1;32m"
 RED="\\033[1;31m"
 YELLOW="\\e[0;33m"
@@ -43,6 +42,13 @@ arkserverLog="arkserver.log"    # here is logged the output of ShooterGameServer
 #---------------------
 # functions
 #---------------------
+
+#
+# timestamp
+#
+timestamp() {
+  date +%T
+}
 
 #
 # check configuration and report errors
@@ -222,11 +228,11 @@ doStart() {
 
     arkserveropts="${arkserveropts}?listen"
     # run the server in background
-    echo "$timestamp: start" >> "$logdir/$arkserverLog"
+    echo "`timestamp`: start" >> "$logdir/$arkserverLog"
     # set max open files limit before we start the server
     ulimit -n $maxOpenFiles
     nohup "$arkserverroot/$arkserverexec" "$arkserveropts" </dev/null >"$logdir/$arkserverLog" 2>&1 & # output of this command is logged
-    echo "$timestamp: start" >> "$logdir/$arkmanagerLog"
+    echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
     tput rc; tput ed;
     echo "The server is now up"
   fi
@@ -245,7 +251,7 @@ doStop() {
 
     tput rc; tput ed;
     echo "The server has been stopped"
-    echo "$timestamp: stop" >> "$logdir/$arkmanagerLog"
+    echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
   else
     echo "The server is already stopped"
   fi
@@ -274,7 +280,7 @@ doUpdate() {
     forceUpdate
   else
     echo "Your server is already up to date! The most recent version is ${bnumber}."
-    echo "$timestamp: No update needed." >> "$logdir/update.log"
+    echo "`timestamp`: No update needed." >> "$logdir/update.log"
   fi;
 }
 
@@ -289,7 +295,7 @@ forceUpdate(){
   ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid +quit
   # the current version should be the last version. We set our version
   getCurrentVersion
-  echo "$timestamp: update to $instver complete" >> "$logdir/update.log"
+  echo "`timestamp`: update to $instver complete" >> "$logdir/update.log"
 
   # we restart the server only if it was started before the update
   if [ $serverWasAlive -eq 1 ]; then
@@ -305,14 +311,14 @@ safeUpdate(){
   
   if isUpdateNeeded; then
     while [ ! `find $arkserverroot/ShooterGame/Saved/SavedArks -mmin -1 -name $serverMap.ark` ]; do
-	  echo "$timestamp: Save file older than 1 minute. Delaying update." >> "$logdir/update.log"
+	  echo "`timestamp`: Save file older than 1 minute. Delaying update." >> "$logdir/update.log"
 	  sleep 30s
     done
-    echo "$timestamp: Save file newer than 1 minute. Performing an update." >> "$logdir/update.log"
+    echo "`timestamp`: Save file newer than 1 minute. Performing an update." >> "$logdir/update.log"
     forceUpdate
   else
     echo "Your server is already up to date! The most recent version is ${bnumber}."
-    echo "$timestamp: No update needed." >> "$logdir/update.log"
+    echo "`timestamp`: No update needed." >> "$logdir/update.log"
   fi
 }
 
@@ -369,11 +375,11 @@ case "$1" in
     ;;
     restart)
         doStop
-        echo "$timestamp: stop" >> "$logdir/$arkmanagerLog"
+        echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
         sleep 10
         doStart
-        echo "$timestamp: start" >> "$logdir/$arkmanagerLog"
-        echo "$timestamp: restart" >> "$logdir/$arkmanagerLog"
+        echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
+        echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"
     ;;
     install)
         doInstall

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -226,7 +226,7 @@ doRun() {
   # set max open files limit before we start the server
   ulimit -n $maxOpenFiles
   "$arkserverroot/$arkserverexec" "$arkserveropts"
-  
+  echo "`timestamp`: exited with status $?"
 }
 
 #

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -86,7 +86,10 @@ if [ ! -z "$1" ]; then
     # Copy arkmanager.cfg inside linux configuation folder if it doesn't already exists
     mkdir -p "${INSTALL_ROOT}/etc/arkmanager"
     if [ -f "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg" ]; then
+      cp -n arkmanager.cfg "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
+      chown "$1" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
+      echo "A copy of the new configuration file was included in /etc/arkmanager. Make sure to review any changes and update your config accordingly!"
       exit 2
     else
       cp -n arkmanager.cfg "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"

--- a/tools/lsb/arkdaemon
+++ b/tools/lsb/arkdaemon
@@ -28,6 +28,7 @@ test -x $DAEMON || exit 5
 case "$1" in
   start)
     log_daemon_msg "Starting" "$NAME"
+    ulimit -n 100000
     su -s /bin/sh -c "$DAEMON start" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
@@ -53,6 +54,7 @@ case "$1" in
   ;;
 
   restart)
+    ulimit -n 100000
     su -s /bin/sh -c "$DAEMON restart" $steamcmd_user
   ;;
 

--- a/tools/openrc/arkdaemon
+++ b/tools/openrc/arkdaemon
@@ -14,6 +14,7 @@ depend(){
 
 start(){
     ebegin "Starting ARK manager daemon"
+    ulimit -n 100000
     su -s /bin/sh -c "$DAEMON start" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`

--- a/tools/redhat/arkdaemon
+++ b/tools/redhat/arkdaemon
@@ -42,6 +42,7 @@ test -x $DAEMON || exit 5
 case "$1" in
   start)
     echo -n "Starting $NAME: "
+    ulimit -n 100000
     su -s /bin/sh -c "$DAEMON start" $steamcmd_user > /dev/null
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
@@ -74,6 +75,7 @@ case "$1" in
 
   restart)
     echo -n "Restarting $NAME: "
+    ulimit -n 100000
     su -s /bin/sh -c "$DAEMON restart" $steamcmd_user > /dev/null
     echo "OK"
   ;;

--- a/tools/systemd/arkdaemon.init
+++ b/tools/systemd/arkdaemon.init
@@ -39,6 +39,7 @@ test -x $DAEMON || exit 5
 case "$1" in
   start)
     echo -n "Starting $NAME: "
+    ulimit -n 100000
     su -s /bin/sh -c "$DAEMON start" $steamcmd_user > /dev/null
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
@@ -69,6 +70,7 @@ case "$1" in
 
   restart)
     echo -n "Restarting $NAME: "
+    ulimit -n 100000
     su -s /bin/sh -c "$DAEMON restart" $steamcmd_user > /dev/null
     echo "OK"
   ;;


### PR DESCRIPTION
First bring in the commits from master, excluding the revert of fff32d0 and 4c34eaf

Increase the open file limits through the init script, as unprivileged users don't have permission to increase those limits.

Replace the timestamp variable with a function, capturing the current time when logging, rather than the script's start time.

Add a doRun function, which performs the initialization and running the server.  Background this as a subprocess.

Log the exit status of the server when it exits.