### PR TITLE
Removes email from config

### DIFF
--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -25,6 +25,3 @@ logdir="/var/log/arktools"                                          # Logs path 
 
 # steamdb specific
 appid=376030                                                        # Linux server App ID
-
-# admin information
-servermail=""                                                       # Log email, leave blank if you dont want to receive mail


### PR DESCRIPTION
Email was removed from arkmanager some commits ago. Having it in the config files could possibly cause issues with dropped items vanishing.

Reported in https://github.com/FezVrasta/ark-server-tools/issues/81