### PR TITLE
Change to the ark server root directory

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -164,6 +164,8 @@ doStart() {
     tput sc
     echo "The server is starting..."
 
+    cd "$arkserverroot"
+
     arkserveropts=$serverMap
 
     # bring in ark_... options


### PR DESCRIPTION
This changes the current working directory to the ARK server root directory when starting, in order to prevent potentially undefined behaviour.