### PR TITLE
Explain variables affecting install; Discover path of lsof

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -25,6 +25,11 @@ if [ -f "${HOME}/.arkmanager.cfg" ]; then
     source "${HOME}/.arkmanager.cfg"
 fi
 
+lsof=lsof
+if [ -x /usr/sbin/lsof ]; then
+  lsof=/usr/sbin/lsof
+fi
+
 # Local variables
 info=""
 thejob=""
@@ -142,7 +147,7 @@ function isTheServerRunning(){
 #
 #
 function isTheServerUp(){
-  lsof -i :"$ark_Port" > /dev/null
+  $lsof -i :"$ark_Port" > /dev/null
   result=$?
   # In this case, the result is:
   # 1 if the command fail. The port is not listenning

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -103,6 +103,12 @@ if [ ! -z "$1" ]; then
 else
     echo "You must specify your system steam user who own steamcmd directory to install ARK Tools."
     echo "Usage: ./install.sh steam"
+    echo
+    echo "Environment variables affecting install:"
+    echo "EXECPREFIX:   prefix in which to install arkmanager executable"
+    echo "              [${EXECPREFIX}]"
+    echo "INSTALL_ROOT: staging directory in which to perform install"
+    echo "              [${INSTALL_ROOT}]"
     exit 1
 fi
 


### PR DESCRIPTION
9313d72 should make it more obvious what effects the environment variables affecting install have.

f7ccbfe takes into account that some distributions (RedHat-based in particular) have lsof in /usr/sbin, while many other distributions have lsof in /usr/bin.  This fixes #93 where lsof is in /usr/sbin/lsof