### PR TITLE
Fix a couple of typos for v1.2

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -80,7 +80,7 @@ checkConfig() {
   fi
   # arkserverexec
   if [ ! -f "$arkserverroot/$arkserverexec" ] ; then
-    echo -e "[" "$YELLOW" "WARN" "$NORMAL" "]" "\tYour SteamCMD exec could not be found."
+    echo -e "[" "$YELLOW" "WARN" "$NORMAL" "]" "\tYour ARK server exec could not be found."
   fi
 
   # Service configuration

--- a/tools/openrc/arkdaemon
+++ b/tools/openrc/arkdaemon
@@ -9,7 +9,7 @@ LOGFILE="${logdir}/${NAME}.log"
 DAEMON="/usr/bin/arkmanager"
 
 depend(){
-    require net
+    need net
 }
 
 start(){


### PR DESCRIPTION
Fix a couple of typos:
* Fix a typo in tools/arkmanager - says the SteamCMD exec could not be found, when it should say the ARK server exec could not be found.
* Fix a typo in tools/openrc/arkdaemon - should be `need net`, not `require net`