### PR TITLE
RCON and Server Query implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ restarts ARK server
 #### arkmanager update
 manually updates ARK server if a new version is available
 
-#### arkmanager forceupdate
+#### arkmanager update --force
 Apply update without check the current version
 
-#### arkmanager safeupdate
+#### arkmanager update --safe
 Waits for server to perform world save and then updates.
 
 #### arkmanager status

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -91,6 +91,80 @@ checkConfig() {
 }
 
 #
+# Get server admin password
+#
+getAdminPassword() {
+  if [ -n "${ark_ServerAdminPassword}" ]; then
+    echo "${ark_ServerAdminPassword}"
+  else
+    sed -ne '/^\[ServerSettings\]/,/^\[.*\]/{s/^ServerAdminPassword[[:space:]]*=[[:space:]]*//p;}' "${arkserverroot}/ShooterGame/Saved/Config/LinuxServer/GameUserSettings.ini"
+  fi
+}
+
+#
+# Execute RCON command
+#
+rconcmd() {
+  perl -MSocket -e '
+    sub sendpkt {
+      my ($sock, $reqid, $reqtype, $body) = @_;
+      my $packet = pack("VVV", length($body) + 10, $reqid, $reqtype) . $body . "\0\0";
+      send($sock, $packet, 0) or die "Error sending command to server";
+    }
+
+    sub recvpkt {
+      my ($sock) = @_;
+      my $data = "";
+      recv($sock, $data, 12, 0);
+      my ($pktlen, $resid, $restype) = unpack("VVV", $data);
+      recv($sock, $data, $pktlen - 8, 0);
+      return ($resid, $restype, substr($data, 0, $pktlen - 10));
+    }
+
+    sub auth {
+      my ($sock, $password) = @_;
+      my $reqid = 1;
+      sendpkt($sock, $reqid, 3, $password);
+      my ($resid, $restype, $rcvbody) = recvpkt($sock);
+      die "Authentication failed" if $resid == -1;
+    }
+
+    my $port = $ARGV[0];
+    my $password = $ARGV[1];
+    my $command = $ARGV[2];
+    socket(my $socket, PF_INET, SOCK_STREAM, 0);
+    setsockopt($socket, SOL_SOCKET, SO_RCVTIMEO, pack("i4", 30, 0, 0, 0));
+    my $sockaddr = pack_sockaddr_in($port, inet_aton("127.0.0.1"));
+    connect($socket, $sockaddr) or die "Error connecting to server";
+    auth($socket, $password);
+    sendpkt($socket, 2, 2, $command);
+    my ($resid, $restype, $rcvbody) = recvpkt($socket);
+    print $rcvbody, "\n";
+    ' "${ark_RCONPort}" "`getAdminPassword`" "$1"
+}
+
+#
+# Save world
+#
+doSaveWorld() {
+  rconcmd saveworld
+}
+
+#
+# Exit cleanly
+#
+doExitServer() {
+  rconcmd doexit
+}
+
+#
+# Broadcast message
+#
+doBroadcast(){
+  rconcmd "broadcast $1"
+}
+
+#
 # Check if a new version is available but not apply it
 #
 function checkForUpdate(){
@@ -425,7 +499,10 @@ case "$1" in
       doBackup
     ;;
     broadcast)
-        doInfo $2
+      doBroadcast $2
+    ;;
+    saveworld)
+      doSaveWorld
     ;;
     status)
       printStatus
@@ -437,6 +514,8 @@ case "$1" in
       echo -e "Usage: arkmanager[OPTION]\n"
       echo "Option            Description"
       echo "backup            Saves a backup of your server inside the backup directory"
+      echo "broadcast <msg>   Sends a message to all users connected to server"
+      echo "saveworld         Saves the game world to disk"
       echo "checkupdate       Check for a new ARK server version"
       echo "install           Install the ARK server files from steamcmd"
       echo "restart           Stops the server and then starts it"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -161,7 +161,7 @@ doExitServer() {
 # Broadcast message
 #
 doBroadcast(){
-  rconcmd "broadcast $1"
+  rconcmd "broadcast $1" >/dev/null
 }
 
 #

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -414,7 +414,7 @@ case "$1" in
           forceUpdate
         elif [ "$2" == "--safe" ]; then
           doSafeUpdate
-        else; then
+        else
           doUpdate
         fi
     ;;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -517,6 +517,9 @@ case "$1" in
     saveworld)
       doSaveWorld
     ;;
+    rconcmd)
+      rconcmd "$2"
+    ;;
     status)
       printStatus
     ;;
@@ -529,6 +532,7 @@ case "$1" in
       echo "backup            Saves a backup of your server inside the backup directory"
       echo "broadcast <msg>   Sends a message to all users connected to server"
       echo "saveworld         Saves the game world to disk"
+      echo "rconcmd <cmd>     Execute RCON command on server"
       echo "checkupdate       Check for a new ARK server version"
       echo "install           Install the ARK server files from steamcmd"
       echo "restart           Stops the server and then starts it"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -512,7 +512,7 @@ case "$1" in
       doBackup
     ;;
     broadcast)
-      doBroadcast $2
+      doBroadcast "$2"
     ;;
     saveworld)
       doSaveWorld

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -436,10 +436,23 @@ printStatus(){
     echo -e "$NORMAL" "Server online: " "$RED" "No" "$NORMAL"
   else
     echo -e "$NORMAL" "Server online: " "$GREEN" "Yes" "$NORMAL"
+    perl -MSocket -e '
+      my $port = int($ARGV[0]);
+      socket(my $socket, PF_INET, SOCK_DGRAM, 0);
+      setsockopt($socket, SOL_SOCKET, SO_RCVTIMEO, pack("i4", 1, 0, 0, 0));
+      my $sockaddr = pack_sockaddr_in($port, inet_aton("127.0.0.1"));
+      send($socket, "\xff\xff\xff\xffTSource Engine Query\x00", 0, $sockaddr);
+      my $data = "";
+      recv($socket, $data, 1400, 0) or (print "Unable to query server\n" and exit(1));
+      my ($servername, $mapname, $game, $fullname, $rest) = split(/\x00/, substr($data, 6), 5);
+      my $players = ord(substr($rest, 2, 1));
+      my $maxplayers = ord(substr($rest, 3, 1));
+      print "Server Name: $servername\n";
+      print "Players: $players / $maxplayers\n";
+      ' "${ark_QueryPort}"
   fi
   getCurrentVersion
   echo -e "$NORMAL" "Server version: " "$GREEN" $instver "$NORMAL"
-
 }
 
 doUpgrade() {


### PR DESCRIPTION
d458b34 implements a simple RCON client in perl as an inline script, and adds two new commands (`saveworld` and `broadcast`) to arkmanager.  This should resolve #54.

2261c82 queries the server to get the server name (including version) and number of players online.  This was suggested in #57.

The server responds to broadcasts (and probably some other commands) with "Server received, But no response!!".  c19ac06 hides this unhelpful response.

73f0134 fixes a problem I noticed in d458b34.

c93742e adds a `rconcmd` command to arkmanager.

The other two commits are from #107