### PR TITLE
Moved arkserverroot parent directory check to the install function

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -74,10 +74,6 @@ checkConfig() {
   fi
 
   # Environment configuration
-  # arkserverroot
-  if [ ! -w `echo "$arkserverroot" | sed 's:/[^/]*$::'` ] ; then
-    echo -e "[" "$RED" "ERROR" "$NORMAL" "]" "\tYou have not rights to write in the defined ARK server root directory"
-  fi
   # arkserverexec
   if [ ! -f "$arkserverroot/$arkserverexec" ] ; then
     echo -e "[" "$YELLOW" "WARN" "$NORMAL" "]" "\tYour ARK server exec could not be found."
@@ -274,7 +270,16 @@ doStop() {
 # install of ARK server
 #
 doInstall() {
-  mkdir -p "$arkserverroot"
+  # Check if arkserverroot already exists
+  if [ ! -d "$arkserverroot" ]; then
+    # If it does not exist, try create it
+    echo -e "Creating the ARK server root directory ($arkserverroot)"
+    mkdir -p "$arkserverroot"
+    if [ ! $? ] ; then
+      echo -e "[" "$RED" "ERROR" "$NORMAL" "]" "\tFailed to create the defined ARK server root directory ($arkserverroot)"
+      exit 1
+    fi
+  fi
 
   cd "$steamcmdroot"
   # install the server


### PR DESCRIPTION
Moves the check for being able to write to the parent of arkserverroot to the install function.

Allows pre-creation of the arkserverroot.

For my install I created /ssh/ark as root, and changed its ownership to steam before running the install script. Steam does not have write permission to /ssd, but it does have write permission to /ssh/ark

Before this fix, I would get an error on every script run.


Ref Issue #110 