### PR TITLE
Fix: steamcmd_appinfocache path

### DIFF
--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -5,7 +5,7 @@ arkstChannel="master"                                               # change it 
 steamcmdroot="/home/steam/steamcmd"                                 # path of your steamcmd instance
 steamcmdexec="steamcmd.sh"                                          # name of steamcmd executable
 steamcmd_user="steam"                                               # name of the system user who own steamcmd folder
-steamcmd_appinfocache="/home/steam/Steam/appcache/appinfo.vdf"      # cache of the appinfo command
+steamcmd_appinfocache="$steamcmdroot/appcache/appinfo.vdf"          # cache of the appinfo command
 
 # config environment
 arkserverroot="/home/steam/ARK"                                     # path of your ARK server files (default ~/ARK)


### PR DESCRIPTION
The path should be under steamcmd directory. Fixed issue with "arkmanager checkupdate" returning "server is up to date" even when the server is out-of-date.