### PR TITLE
1.3 dev features

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -531,13 +531,17 @@ printStatus(){
 }
 
 doUpgrade() {
+  local sudo=sudo
+  if [ "$steamcmd_user" == "me" ]; then
+    sudo=
+  fi
   echo "arkmanager v${arkstVersion}: Checking for updates..."
   arkstLatestVersion=`curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/.version`
   if [[ $arkstLatestVersion > $arkstVersion ]]; then
     read -p "A new version was found! Do you want to upgrade ARK Server Tools to v${$arkstLatestVersion}?" -n 1 -r
     echo -en "\n"
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-        curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | sudo bash -s ${steamcmd_user} ${arkstChannel}
+        curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s ${steamcmd_user} ${arkstChannel}
       else
         exit 0
     fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -630,7 +630,12 @@ while true; do
       exit 1
     ;;
     *)
-      echo "arkmanager v${arkstVersion}: no command specified"
+      echo -n "arkmanager v${arkstVersion}: "
+      if [ $# -eq 0 ]; then
+        echo "no command specified"
+      else
+        echo "unknown command '$1' specified"
+      fi
       echo "Try 'arkmanager -h' or 'arkmanager --help' for more information."
       exit 1
     ;;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -557,7 +557,8 @@ doUpgrade() {
 # check the configuration and throw errors or warnings if needed
 checkConfig
 
-case "$1" in
+while true; do
+  case "$1" in
     start)
         doStart
     ;;
@@ -578,8 +579,10 @@ case "$1" in
     update)
         if [ "$2" == "--force" ]; then
           forceUpdate
+	  shift
         elif [ "$2" == "--safe" ]; then
           doSafeUpdate
+	  shift
         else
           doUpdate
         fi
@@ -592,12 +595,14 @@ case "$1" in
     ;;
     broadcast)
       doBroadcast "$2"
+      shift
     ;;
     saveworld)
       doSaveWorld
     ;;
     rconcmd)
       rconcmd "$2"
+      shift
     ;;
     status)
       printStatus
@@ -622,9 +627,16 @@ case "$1" in
       echo "update --force    Apply update without check the current version"
       echo "update --safe     Wait for server to perform world save and update."
       echo "upgrade           Check for a new ARK Server Tools version and upgrades it if needed"
+      exit 1
     ;;
     *)
       echo "arkmanager v${arkstVersion}: no command specified"
       echo "Try 'arkmanager -h' or 'arkmanager --help' for more information."
+      exit 1
     ;;
-esac
+  esac
+  shift
+  if [ $# -eq 0 ]; then
+    break
+  fi
+done

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -328,7 +328,7 @@ doStop() {
     echo "Stopping server..."
     # kill the server with the PID
     PID=`ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'`
-    kill -9 $PID
+    kill -INT $PID
 
     tput rc; tput ed;
     echo "The server has been stopped"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -550,6 +550,16 @@ doUpgrade() {
   fi
 }
 
+useConfig() {
+  for varname in "${!configfile_@}"; do
+    if [ "configfile_$1" == "$varname" ]; then
+      source "${!varname}"
+      return
+    fi
+  done
+  source "$1"
+}
+
 #---------------------
 # Main program
 #---------------------
@@ -610,6 +620,10 @@ while true; do
     upgrade)
       doUpgrade
     ;;
+    useconfig)
+      useConfig "$2"
+      shift
+    ;;
     -h|--help)
       echo -e "Usage: arkmanager [OPTION]\n"
       echo "Option            Description"
@@ -627,6 +641,7 @@ while true; do
       echo "update --force    Apply update without check the current version"
       echo "update --safe     Wait for server to perform world save and update."
       echo "upgrade           Check for a new ARK Server Tools version and upgrades it if needed"
+      echo "useconfig <name>  Use the configuration overrides in the specified config name or file"
       exit 1
     ;;
     *)

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -31,3 +31,7 @@ logdir="/var/log/arktools"                                          # Logs path 
 
 # steamdb specific
 appid=376030                                                        # Linux server App ID
+
+# alternate configs
+# example for config name "ark1":
+#config_ark1="/path/to/config/file"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,8 +1,34 @@
 #!/bin/bash
 
-EXECPREFIX="${EXECPREFIX:-/usr/local}"
+if [ "$1" == "me" ]; then
+  PREFIX="${PREFIX:-${HOME}}"
+  EXECPREFIX="${EXECPREFIX:-${PREFIX}}"
+else
+  EXECPREFIX="${EXECPREFIX:-/usr/local}"
+fi
 
 if [ ! -z "$1" ]; then
+  if [ "$1" == "me" -a "$UID" -ne 0 ]; then
+    # Copy arkmanager to ~/bin
+    mkdir -p "${INSTALL_ROOT}${EXECPREFIX}/bin"
+    cp arkmanager "${INSTALL_ROOT}${EXECPREFIX}/bin/arkmanager"
+    chmod +x "${INSTALL_ROOT}${EXECPREFIX}/bin/arkmanager"
+
+    # Create a folder in ~/logs to let Ark tools write its own log files
+    mkdir -p "${INSTALL_ROOT}${PREFIX}/logs/arktools"
+
+    # Copy arkmanager.cfg to ~/.arkmanager.cfg if it doesn't already exist
+    if [ -f "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg" ]; then
+      cp -n arkmanager.cfg "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
+      sed -i "s|^steamcmd_user=\"steam\"|steamcmd_user=\"me\"|;s|\"/home/steam|\"${PREFIX}|;s|/var/log/arktools|${PREFIX}/logs/arktools|" "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
+      echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
+      echo "A copy of the new configuration file was included in '${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW'. Make sure to review any changes and update your config accordingly!"
+      exit 2
+    else
+      cp -n arkmanager.cfg "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
+      sed -i "s|^steamcmd_user=\"steam\"|steamcmd_user=\"me\"|;s|\"/home/steam|\"${PREFIX}|;s|/var/log/arktools|${PREFIX}/logs/arktools|" "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
+    fi
+  else
     # Copy arkmanager to /usr/bin and set permissions
     cp arkmanager "${INSTALL_ROOT}${EXECPREFIX}/bin/arkmanager"
     chmod +x "${INSTALL_ROOT}${EXECPREFIX}/bin/arkmanager"
@@ -99,7 +125,7 @@ if [ ! -z "$1" ]; then
       chown "$1" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
       sed -i "s|^steamcmd_user=\"steam\"|steamcmd_user=\"$1\"|;s|\"/home/steam|\"/home/$1|" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
     fi
-
+  fi
 else
     echo "You must specify your system steam user who own steamcmd directory to install ARK Tools."
     echo "Usage: ./install.sh steam"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -28,6 +28,9 @@ if [ ! -z "$1" ]; then
       cp -n arkmanager.cfg "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
       sed -i "s|^steamcmd_user=\"steam\"|steamcmd_user=\"me\"|;s|\"/home/steam|\"${PREFIX}|;s|/var/log/arktools|${PREFIX}/logs/arktools|" "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
     fi
+  elif [ "$1" == "me" ]; then
+    echo "You specified the special 'me' user while running as root. This is not permitted."
+    exit 1
   else
     # Copy arkmanager to /usr/bin and set permissions
     cp arkmanager "${INSTALL_ROOT}${EXECPREFIX}/bin/arkmanager"


### PR DESCRIPTION
First, pull in the changes from master.

8e881f8 adds the ability to install using a special "me" user, which will cause the installer to perform a user-local install instead of a system-wide install, as suggested in #123.

9f4a073 switches from using `SIGKILL` to using `SIGINT` (emulating Control-C), thus allowing the server to save the world before exiting.  Should fix #125, though may need to be followed-up with either another `SIGINT` or a `SIGKILL` if the server hasn't exited in a timely manner.  Another possibility instead of what is done here could be to do a `rconcmd doexit`, and if that fails (or if the RCON port is not yet open) then kill the process.

a3ee969 adds support for multiple commands in a single invocation, as suggested in #68.

5673c3a informs the user which command was not understood.

23d564b allows the user to specify a configuration name or config file from which to source overrides for variables in the system and/or user config files.  Should allow what was suggested in #62.

3444077 disallows using the special 'me' user when installing as root.  Previously, the initial install would have attempted to install under a user named 'me', and any subsequent upgrades would have attempted a user-install.