### PR TITLE
1.3 dev stop/restart

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -585,7 +585,7 @@ case "$1" in
     restart)
         doStop
         echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
-        sleep 10
+        sleep 1
         doStart
         echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
         echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -244,13 +244,21 @@ function getAvailableVersion(){
 }
 
 #
+# Get the PID of the server process
+#
+function getServerPID(){
+  ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'
+}
+
+#
 # Check id the server process is alive
 #
 function isTheServerRunning(){
-  SERVICE="ShooterGameServer"
-  ps aux | grep -v grep | grep $SERVICE > /dev/null
-  result=$?
-  return $result
+  if [ -n "`getServerPID`" ]; then
+    return 0
+  else
+    return 1
+  fi
 }
 
 #
@@ -327,7 +335,7 @@ doStop() {
     tput sc
     echo "Stopping server..."
     # kill the server with the PID
-    PID=`ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'`
+    PID=`getServerPID`
     kill -INT $PID
 
     tput rc; tput ed;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -328,7 +328,7 @@ doStop() {
     echo "Stopping server..."
     # kill the server with the PID
     PID=`ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'`
-    kill -9 $PID
+    kill -INT $PID
 
     tput rc; tput ed;
     echo "The server has been stopped"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -334,13 +334,27 @@ doStop() {
   if isTheServerRunning; then
     tput sc
     echo "Stopping server..."
+    echo "`timestamp`: stopping" >> "$logdir/$arkmanagerLog"
     # kill the server with the PID
     PID=`getServerPID`
     kill -INT $PID
 
+    for (( i = 0; i < 10; i++ )); do
+      sleep 1
+      if ! isTheServerRunning; then
+        break
+      fi
+    done
+
+    if isTheServerRunning; then
+      tput rc
+      echo "Killing server..."
+      kill -KILL $PID
+    fi
+
     tput rc; tput ed;
     echo "The server has been stopped"
-    echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
+    echo "`timestamp`: stopped" >> "$logdir/$arkmanagerLog"
   else
     echo "The server is already stopped"
   fi


### PR DESCRIPTION
2110bc7 shuts down the server using SIGINT, which invokes the CtrlCHandler and saves the world.

3759904 moves the PID discovery out of doStop, and uses it to check if the server is running.  This should prevent other instances of the server from being detected and causing startup to fail.

ac41f14 waits for up to 10 seconds for the server to stop, and if the server is still running after 10 seconds then it kills it.  A normal shutdown generally only takes 2-3 seconds.

f2ff580 reduces the wait between stop and start to 1 second.  This and the previous commit should reduce if not eliminate the likely cause of #129.