### PR TITLE
1.3-dev mod support

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -452,7 +452,7 @@ doBackup(){
   # If both attempts fail, server may have
   # crashed between unlink and rename
   if [ ! -f "${backupdir}/${serverMap##*/}.ark" ]; then
-    cp -p "${arkserverroot}/ShooterGame/Saved/SavedArks/${serverMap}.tmp" "${backupdir##*/}/${serverMap##*/}.ark"
+    cp -p "${arkserverroot}/ShooterGame/Saved/SavedArks/${serverMap##*/}.tmp" "${backupdir##*/}/${serverMap##*/}.ark"
   fi
   if [ -f "${backupdir}/${serverMap##*/}.ark" ]; then
     echo -e "${NORMAL}[   ${GREEN}OK${NORMAL}   ]"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -284,6 +284,10 @@ function isTheServerUp(){
 doRun() {
   arkserveropts="$serverMap"
 
+  if [ -n "$serverMapModId" ]; then
+    arkserveropts="-MapModID=$serverMapModId"
+  fi
+
   # bring in ark_... options
   for varname in "${!ark_@}"; do
     name="${varname#ark_}"
@@ -441,6 +445,20 @@ doBackup(){
   local datestamp=`date +"%Y-%m-%d_%H.%M.%S"`
   local backupdir="${arkbackupdir}/${datestamp}"
   mkdir -p "$backupdir"
+
+  # extract the map name from the active map mod
+  if [ -n "$serverMapModId" ]; then
+    serverMap="$(perl -e '
+      my $data;
+      { local $/; $data = <>; }
+      my $mapnamelen = unpack("@0 L<", $data);
+      my $mapname = substr($data, 4, $mapnamelen - 1);
+      $mapnamelen += 4;
+      my $mapfilelen = unpack("@" . ($mapnamelen + 4) . " L<", $data);
+      my $mapfile = substr($data, $mapnamelen + 8, $mapfilelen - 1);
+      print $mapfile;
+    ' <"${arkserverroot}/ShooterGame/Content/Mods/${serverMapModId}/mod.info")"
+  fi
 
   # ARK server uses Write-Unlink-Rename
   echo -ne "${NORMAL} Copying ARK world file "

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -16,6 +16,7 @@ arkbackupdir="/home/steam/ARK-Backups"                              # path to ba
 # comment out these values if you want to define them
 # inside your GameUserSettings.ini file
 serverMap="TheIsland"                                               # server map (default TheIsland)
+#serverMapModId="469987622"                                         # Uncomment this to specify the Map Mod Id (<fileid> in http://steamcommunity.com/sharedfiles/filedetails/?id=<fileid>)
 ark_RCONEnabled="True"                                              # Enable RCON Protocol
 ark_RCONPort="32330"                                                # RCON Port
 ark_SessionName="ARK Server Tools"                                  # if your session name needs special characters please use the .ini instead
@@ -24,6 +25,7 @@ ark_QueryPort="27016"                                               # ARK query 
 ark_ServerPassword=""                                               # ARK server password, empty: no password required to login
 ark_ServerAdminPassword="keyboardcat"                               # ARK server admin password, KEEP IT SAFE!
 ark_MaxPlayers="70"
+#ark_GameModIds="487516323,487516324,487516325"                     # Uncomment to specify additional mods by Mod Id separated by commas
 
 # config Service
 servicename="arkserv"                                               # Name of the service (don't change if you don't know what are you doing)


### PR DESCRIPTION
2e8e3b6 fixes where I missed extracting the world name from the server map path.

0aa7546 adds support for the `-MapModId` map specification introduced in ARK: Survival Evolved 193.0