### PR TITLE
1.3-dev multiserver / warn players

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -159,6 +159,14 @@ doBroadcast(){
 }
 
 #
+# Broadcast message with echo
+#
+doBroadcastWithEcho(){
+  echo "$1"
+  doBroadcast "$1"
+}
+
+#
 # Check if a new version is available but not apply it
 #
 function checkForUpdate(){
@@ -439,6 +447,51 @@ doSafeUpdate(){
 }
 
 #
+# Waits for a configurable number of minutes before updating the server
+#
+doWarnUpdate(){
+  cd "$arkserverroot"
+
+  if isUpdateNeeded; then
+    local pid=`getServerPID`
+    if [ -n "$pid" ]; then
+      local warnminutes=$(( arkwarnminutes ))
+      if (( warnminutes == 0 )); then
+        warnminutes=60
+      fi
+
+      local warnintervals=( 90 60 45 30 20 15 10 5 4 3 2 1 )
+
+      for warninterval in "${warnintervals[@]}"; do
+        if [ "`getServerPID`" != "$pid" ]; then
+          echo "Server has stopped.  Aborting update"
+        fi
+        if (( arkwarnminutes > warninterval )); then
+          doBroadcastWithEcho "This ARK server will shutdown for an update in $warnminutes minutes"
+          sleep $(( warnminutes - warninterval ))m
+          warnminutes=$warninterval
+        fi
+      done
+
+      local warnseconds=90
+      warnintervals=( 60 45 30 20 15 10 5 0 )
+      for warninterval in "${warnintervals[@]}"; do
+        if [ "`getServerPID`" != "$pid" ]; then
+          echo "Server has stopped.  Aborting update"
+        fi
+        doBroadcastWithEcho "This ARK server will shutdown for an update in $warnseconds seconds"
+        sleep $(( warnseconds - warninterval ))s
+      done
+    fi
+
+    if [ "`getServerPID`" != "$pid" ]; then
+      echo "Server has stopped.  Aborting update"
+    fi
+    doUpdate
+  fi
+}
+
+#
 # Copies server state to a backup directory
 #
 doBackup(){
@@ -633,6 +686,9 @@ while true; do
         elif [ "$2" == "--safe" ]; then
           doSafeUpdate
 	  shift
+        elif [ "$2" == "--warn" ]; then
+          doWarnUpdate
+          shift
         else
           doUpdate
         fi
@@ -680,6 +736,7 @@ while true; do
       echo "update            Check for a new ARK server version, if needed, stops the server, updates it, and starts it again"
       echo "update --force    Apply update without check the current version"
       echo "update --safe     Wait for server to perform world save and update."
+      echo "update --warn     Warn players before updating server"
       echo "upgrade           Check for a new ARK Server Tools version and upgrades it if needed"
       echo "useconfig <name>  Use the configuration overrides in the specified config name or file"
       exit 1

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -340,6 +340,21 @@ doStart() {
 }
 
 #
+# starts all servers specified by config_xxxxx in config file
+#
+doStartAll(){
+  doStart
+  for cfg in "${!config_@}"; do
+    if [ -f "${!cfg}" ]; then
+      (
+        source "${!cfg}"
+        doStart
+      )
+    fi
+  done
+}
+
+#
 # stop the ARK server
 #
 doStop() {
@@ -370,6 +385,21 @@ doStop() {
   else
     echo "The server is already stopped"
   fi
+}
+
+#
+# stops all servers specified by config_xxxxx in config file
+#
+doStopAll(){
+  doStop
+  for cfg in "${!config_@}"; do
+    if [ -f "${!cfg}" ]; then
+      (
+        source "${!cfg}"
+        doStop
+      )
+    fi
+  done
 }
 
 #
@@ -644,8 +674,8 @@ doUpgrade() {
 }
 
 useConfig() {
-  for varname in "${!configfile_@}"; do
-    if [ "configfile_$1" == "$varname" ]; then
+  for varname in "${!config_@}"; do
+    if [ "config_$1" == "$varname" ]; then
       source "${!varname}"
       return
     fi
@@ -663,16 +693,35 @@ checkConfig
 while true; do
   case "$1" in
     start)
-        doStart
+        if [ "$2" == "--all" ]; then
+          doStartAll
+          shift
+        else
+          doStart
+        fi
     ;;
     stop)
-        doStop
+        if [ "$2" == "--all" ]; then
+          doStopAll
+          shift
+        else
+          doStop
+        fi
     ;;
     restart)
-        doStop
+        if [ "$2" == "--all" ]; then
+	  doStopAll
+	else
+          doStop
+	fi
         echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
         sleep 1
-        doStart
+	if [ "$2" == "--all" ]; then
+          doStartAll
+	  shift
+	else
+	  doStart
+	fi
         echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
         echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"
     ;;
@@ -730,8 +779,11 @@ while true; do
       echo "checkupdate       Check for a new ARK server version"
       echo "install           Install the ARK server files from steamcmd"
       echo "restart           Stops the server and then starts it"
+      echo "restart --all     Restarts all servers specified in config_xxxxx"
       echo "start             Starts the server"
+      echo "start --all       Starts all servers specified in config_xxxxx"
       echo "stop              Stops the server"
+      echo "stop --all        Stops all servers specified in config_xxxxx"
       echo "status            Returns the status of the current ARK server instance"
       echo "update            Check for a new ARK server version, if needed, stops the server, updates it, and starts it again"
       echo "update --force    Apply update without check the current version"

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -11,6 +11,7 @@ steamcmd_appinfocache="/home/steam/Steam/appcache/appinfo.vdf"      # cache of t
 arkserverroot="/home/steam/ARK"                                     # path of your ARK server files (default ~/ARK)
 arkserverexec="ShooterGame/Binaries/Linux/ShooterGameServer"        # name of ARK server executable
 arkbackupdir="/home/steam/ARK-Backups"                              # path to backup directory
+arkwarnminutes="60"                                                 # number of minutes to warn players when using update --warn
 
 # ARK server options - use ark_<optionname>=<value>
 # comment out these values if you want to define them

--- a/tools/lsb/arkdaemon
+++ b/tools/lsb/arkdaemon
@@ -29,7 +29,7 @@ case "$1" in
   start)
     log_daemon_msg "Starting" "$NAME"
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON start" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON start --all" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -42,7 +42,7 @@ case "$1" in
 
   stop)
     log_daemon_msg "Stopping" "$NAME"
-    su -s /bin/sh -c "$DAEMON stop" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON stop --all" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -55,7 +55,7 @@ case "$1" in
 
   restart)
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON restart" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON restart --all" $steamcmd_user
   ;;
 
   status)

--- a/tools/openrc/arkdaemon
+++ b/tools/openrc/arkdaemon
@@ -15,7 +15,7 @@ depend(){
 start(){
     ebegin "Starting ARK manager daemon"
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON start" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON start --all" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -27,7 +27,7 @@ start(){
 
 stop(){
     ebegin "Stopping ARK manager daemon"
-    su -s /bin/sh -c "$DAEMON start" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON stop --all" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then

--- a/tools/redhat/arkdaemon
+++ b/tools/redhat/arkdaemon
@@ -43,7 +43,7 @@ case "$1" in
   start)
     echo -n "Starting $NAME: "
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON start" $steamcmd_user > /dev/null
+    su -s /bin/sh -c "$DAEMON start --all" $steamcmd_user > /dev/null
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -59,7 +59,7 @@ case "$1" in
 
   stop)
     echo -n "Stopping $NAME: "
-    su -s /bin/sh -c "$DAEMON stop" $steamcmd_user > /dev/null
+    su -s /bin/sh -c "$DAEMON stop --all" $steamcmd_user > /dev/null
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -76,7 +76,7 @@ case "$1" in
   restart)
     echo -n "Restarting $NAME: "
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON restart" $steamcmd_user > /dev/null
+    su -s /bin/sh -c "$DAEMON restart --all" $steamcmd_user > /dev/null
     echo "OK"
   ;;
 

--- a/tools/systemd/arkdeamon.service
+++ b/tools/systemd/arkdeamon.service
@@ -3,8 +3,8 @@ Description=Daemon to start ark server
 After=network.target
 
 [Service]
-ExecStart=/usr/libexec/arkmanager/arkmanager.init start
-ExecStop=/usr/libexec/arkmanager/arkmanager.init stop
+ExecStart=/usr/libexec/arkmanager/arkmanager.init start --all
+ExecStop=/usr/libexec/arkmanager/arkmanager.init stop --all
 Type=forking
 PIDFile=/var/run/arkmanager.pid
 


### PR DESCRIPTION
f3df26e adds an option to warn players for a configurable amount of time before updating the server.  This plus a cron job should satisfy #21

6d1a154 adds an option to start / stop all servers specified in the config_*xxxxx* settings in the config file.

904db69 updates the init scripts to use the above option.  This plus the previous commit should satisfy #62.