### PR TITLE
Move script version to script; add hotfix support

### DIFF
--- a/netinstall.sh
+++ b/netinstall.sh
@@ -8,10 +8,14 @@ channel=${2:-master} # if defined by 2nd argument install the defined version, o
 
 # Download and untar installation files
 cd /tmp
-curl -L -k -s https://github.com/FezVrasta/ark-server-tools/archive/${channel}.tar.gz | tar xz
+COMMIT="`curl -L -k -s https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads/${channel} | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`"
+mkdir ark-server-tools-${channel}
+cd ark-server-tools-${channel}
+curl -L -k -s https://github.com/FezVrasta/ark-server-tools/archive/${COMMIT}.tar.gz | tar xz
 
 # Install ARK Server Tools
-cd ark-server-tools-${channel}/tools
+cd ark-server-tools-${COMMIT}/tools
+sed -i "s|^arkstCommit='.*'$|arkstCommit='${COMMIT}'|" arkmanager
 chmod +x install.sh
 sh install.sh $1 > /dev/null
 

--- a/netinstall.sh
+++ b/netinstall.sh
@@ -9,6 +9,20 @@ channel=${2:-master} # if defined by 2nd argument install the defined version, o
 # Download and untar installation files
 cd /tmp
 COMMIT="`curl -L -k -s https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads/${channel} | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`"
+
+if [ -z "$COMMIT" ]; then
+  if [ "$channel" != "master" ]; then
+    echo "Channel ${channel} not found - trying master"
+    channel=master
+    COMMIT="`curl -L -k -s https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads/${channel} | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`"
+  fi
+fi
+
+if [ -z "$COMMIT" ]; then
+  echo "Unable to retrieve latest commit"
+  exit 1
+fi
+
 mkdir ark-server-tools-${channel}
 cd ark-server-tools-${channel}
 curl -L -k -s https://github.com/FezVrasta/ark-server-tools/archive/${COMMIT}.tar.gz | tar xz

--- a/netinstall.sh
+++ b/netinstall.sh
@@ -33,7 +33,7 @@ sed -i "s|^arkstCommit='.*'$|arkstCommit='${COMMIT}'|" arkmanager
 version=`<../.version`
 sed -i "s|^arkstVersion=\".*\"|arkstVersion='${version}'|" arkmanager
 chmod +x install.sh
-sh install.sh $1 > /dev/null
+bash install.sh $1 > /dev/null
 
 status=$?
 

--- a/netinstall.sh
+++ b/netinstall.sh
@@ -30,6 +30,8 @@ curl -L -k -s https://github.com/FezVrasta/ark-server-tools/archive/${COMMIT}.ta
 # Install ARK Server Tools
 cd ark-server-tools-${COMMIT}/tools
 sed -i "s|^arkstCommit='.*'$|arkstCommit='${COMMIT}'|" arkmanager
+version=`<../.version`
+sed -i "s|^arkstVersion=\".*\"|arkstVersion='${version}'|" arkmanager
 chmod +x install.sh
 sh install.sh $1 > /dev/null
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -581,8 +581,17 @@ doUpgrade() {
   fi
   echo "arkmanager v${arkstVersion}: Checking for updates..."
   arkstLatestVersion=`curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/.version`
+  arkstLatestCommit=`curl -s https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads/${arkstChannel} | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`
   if [[ $arkstLatestVersion > $arkstVersion ]]; then
     read -p "A new version was found! Do you want to upgrade ARK Server Tools to v${arkstLatestVersion}?" -n 1 -r
+    echo -en "\n"
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s ${steamcmd_user} ${arkstChannel}
+      else
+        exit 0
+    fi
+  elif [[ "$arkstLatestCommit" != "$arkstCommit" ]]; then
+    read -p "A hotfix is available for v${arkstLatestVersion}.  Do you wish to install it?" -n 1 -r
     echo -en "\n"
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s ${steamcmd_user} ${arkstChannel}

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -44,6 +44,7 @@ arkserverLog="arkserver.log"    # here is logged the output of ShooterGameServer
 
 # Script version
 arkstVersion="1.3"
+arkstCommit=''
 
 #---------------------
 # functions

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -42,6 +42,9 @@ maxOpenFiles=100000
 arkmanagerLog="arkmanager.log"  # here are logged the actions performed by arkmanager
 arkserverLog="arkserver.log"    # here is logged the output of ShooterGameServer
 
+# Script version
+arkstVersion="1.3"
+
 #---------------------
 # functions
 #---------------------

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -1,4 +1,3 @@
-arkstVersion="1.2"                                                  # used to print the version when needed and to check for updates
 arkstChannel="master"                                               # change it to a different branch to get non-stable versions
 
 # config SteamCMD


### PR DESCRIPTION
3e0fa90 moves the script version into the script.

10a49b7 retrieves the latest commit on the selected branch, and injects it into the script during install.

74b665c adds hotfix support by retrieving the latest commit and comparing it against the commit injected above

34a3ec8 retries with the master channel if the selected channel branch is not found, and aborts if the master channel is not found.

6ce1847 injects the version from the .version file into the script during install.

8a7f6d2 fixes the issue reported in #153 and #154 where /bin/sh is not bash, by running the install script using bash.