### PR TITLE
1.4 Features

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -586,6 +586,7 @@ doInstallMod(){
 doBackup(){
   local datestamp=`date +"%Y-%m-%d_%H.%M.%S"`
   local backupdir="${arkbackupdir}/${datestamp}"
+  local savedir="SavedArks"
   mkdir -p "$backupdir"
 
   # extract the map name from the active map mod
@@ -602,17 +603,22 @@ doBackup(){
     ' <"${arkserverroot}/ShooterGame/Content/Mods/${serverMapModId}/mod.info")"
   fi
 
+  # Get save directory name
+  if [ -n "${ark_AltSaveDirectoryName}" ]; then
+    savedir="${ark_AltSaveDirectoryName}"
+  fi
+
   # ARK server uses Write-Unlink-Rename
   echo -ne "${NORMAL} Copying ARK world file "
-  cp -p "${arkserverroot}/ShooterGame/Saved/SavedArks/${serverMap##*/}.ark" "${backupdir}/${serverMap##*/}.ark"
+  cp -p "${arkserverroot}/ShooterGame/Saved/${savedir}/${serverMap##*/}.ark" "${backupdir}/${serverMap##*/}.ark"
   if [ ! -f "${backupdir}/${serverMap##*/}.ark" ]; then
     sleep 2
-    cp -p "${arkserverroot}/ShooterGame/Saved/SavedArks/${serverMap##*/}.ark" "${backupdir}/${serverMap##*/}.ark"
+    cp -p "${arkserverroot}/ShooterGame/Saved/${savedir}/${serverMap##*/}.ark" "${backupdir}/${serverMap##*/}.ark"
   fi
   # If both attempts fail, server may have
   # crashed between unlink and rename
   if [ ! -f "${backupdir}/${serverMap##*/}.ark" ]; then
-    cp -p "${arkserverroot}/ShooterGame/Saved/SavedArks/${serverMap##*/}.tmp" "${backupdir##*/}/${serverMap##*/}.ark"
+    cp -p "${arkserverroot}/ShooterGame/Saved/${savedir}/${serverMap##*/}.tmp" "${backupdir##*/}/${serverMap##*/}.ark"
   fi
   if [ -f "${backupdir}/${serverMap##*/}.ark" ]; then
     echo -e "${NORMAL}[   ${GREEN}OK${NORMAL}   ]"
@@ -625,7 +631,7 @@ doBackup(){
   # ARK server uses a non-blocking lock and will
   # fail to update the file if the lock fails.
   echo -e "${NORMAL} Copying ARK profile files"
-  for f in "${arkserverroot}/ShooterGame/Saved/SavedArks/"*.arkprofile; do
+  for f in "${arkserverroot}/ShooterGame/Saved/${savedir}/"*.arkprofile; do
     echo -ne "${NORMAL}   ${f##*/} "
     cp -p "${f}" "${backupdir}/${f##*/}"
     if [ ! -s "${backupdir}/${f##*/}" ]; then
@@ -646,7 +652,7 @@ doBackup(){
 
   # ARK server uses Lock-Truncate-Write-Unlock
   echo -e "${NORMAL} Copying ARK tribe files "
-  for f in "${arkserverroot}/ShooterGame/Saved/SavedArks/"*.arktribe; do
+  for f in "${arkserverroot}/ShooterGame/Saved/${savedir}/"*.arktribe; do
     echo -ne "${NORMAL}   ${f##*/} "
     cp -p "${f}" "${backupdir}/${f##*/}"
     if [ ! -s "${backupdir}/${f##*/}" ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -295,6 +295,8 @@ doRun() {
     arkserveropts="-MapModID=$serverMapModId"
   fi
 
+  arkextraopts=( )
+
   # bring in ark_... options
   for varname in "${!ark_@}"; do
     name="${varname#ark_}"
@@ -312,12 +314,23 @@ doRun() {
     fi
   done
 
+  # bring in arkflag_... flags
+  for varname in "${!arkflag_@}"; do
+    name="${varname#arkflag_}"
+    val="${!varname}"
+
+    if [ -n "$val" ]; then
+      arkextraopts=( "${arkextraopts[@]}" "-${name}" )
+    fi
+  done
+
+
   arkserveropts="${arkserveropts}?listen"
   # run the server in background
   echo "`timestamp`: start"
   # set max open files limit before we start the server
   ulimit -n $maxOpenFiles
-  "$arkserverroot/$arkserverexec" "$arkserveropts"
+  "$arkserverroot/$arkserverexec" "$arkserveropts" "${arkextraopts[@]}"
   echo "`timestamp`: exited with status $?"
 }
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -339,6 +339,21 @@ doStart() {
 }
 
 #
+# starts all servers specified by configfile_xxxxx in config file
+#
+doStartAll(){
+  doStart
+  for cfg in "${!configfile_@}"; do
+    if [ -f "${!cfg}" ]; then
+      (
+        source "${!cfg}"
+        doStart
+      )
+    fi
+  done
+}
+
+#
 # stop the ARK server
 #
 doStop() {
@@ -369,6 +384,21 @@ doStop() {
   else
     echo "The server is already stopped"
   fi
+}
+
+#
+# stops all servers specified by configfile_xxxxx in config file
+#
+doStopAll(){
+  doStop
+  for cfg in "${!configfile_@}"; do
+    if [ -f "${!cfg}" ]; then
+      (
+        source "${!cfg}"
+        doStop
+      )
+    fi
+  done
 }
 
 #
@@ -718,16 +748,35 @@ checkConfig
 while true; do
   case "$1" in
     start)
-        doStart
+        if [ "$2" == "--all" ]; then
+          doStartAll
+          shift
+        else
+          doStart
+        fi
     ;;
     stop)
-        doStop
+        if [ "$2" == "--all" ]; then
+          doStopAll
+          shift
+        else
+          doStop
+        fi
     ;;
     restart)
-        doStop
+        if [ "$2" == "--all" ]; then
+	  doStopAll
+	else
+          doStop
+	fi
         echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
         sleep 1
-        doStart
+	if [ "$2" == "--all" ]; then
+          doStartAll
+	  shift
+	else
+	  doStart
+	fi
         echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
         echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"
     ;;
@@ -786,8 +835,11 @@ while true; do
       echo "checkupdate       Check for a new ARK server version"
       echo "install           Install the ARK server files from steamcmd"
       echo "restart           Stops the server and then starts it"
+      echo "restart --all     Restarts all servers specified in configfile_xxxxx"
       echo "start             Starts the server"
+      echo "start --all       Starts all servers specified in configfile_xxxxx"
       echo "stop              Stops the server"
+      echo "stop --all        Stops all servers specified in configfile_xxxxx"
       echo "status            Returns the status of the current ARK server instance"
       echo "update            Check for a new ARK server version, if needed, stops the server, updates it, and starts it again"
       echo "update --force    Apply update without check the current version"

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -36,4 +36,4 @@ mod_appid=346110                                                    # App ID for
 
 # alternate configs
 # example for config name "ark1":
-#config_ark1="/path/to/config/file"
+#configfile_ark1="/path/to/config/file"

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -26,6 +26,7 @@ ark_ServerPassword=""                                               # ARK server
 ark_ServerAdminPassword="keyboardcat"                               # ARK server admin password, KEEP IT SAFE!
 ark_MaxPlayers="70"
 #ark_GameModIds="487516323,487516324,487516325"                     # Uncomment to specify additional mods by Mod Id separated by commas
+#ark_AltSaveDirectoryName="SotF"                                    # Uncomment to specify a different save directory name
 
 # ARK server flags - use arkflag_<optionname>=true
 #arkflag_OnlyAdminRejoinAsSpectator=true                            # Uncomment to only allow admins to rejoin as spectator

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -16,6 +16,7 @@ arkbackupdir="/home/steam/ARK-Backups"                              # path to ba
 # inside your GameUserSettings.ini file
 serverMap="TheIsland"                                               # server map (default TheIsland)
 #serverMapModId="469987622"                                         # Uncomment this to specify the Map Mod Id (<fileid> in http://steamcommunity.com/sharedfiles/filedetails/?id=<fileid>)
+#ark_TotalConversionMod="496735411"                                 # Uncomment this to specify a total-conversion mod
 ark_RCONEnabled="True"                                              # Enable RCON Protocol
 ark_RCONPort="32330"                                                # RCON Port
 ark_SessionName="ARK Server Tools"                                  # if your session name needs special characters please use the .ini instead
@@ -25,6 +26,10 @@ ark_ServerPassword=""                                               # ARK server
 ark_ServerAdminPassword="keyboardcat"                               # ARK server admin password, KEEP IT SAFE!
 ark_MaxPlayers="70"
 #ark_GameModIds="487516323,487516324,487516325"                     # Uncomment to specify additional mods by Mod Id separated by commas
+
+# ARK server flags - use arkflag_<optionname>=true
+#arkflag_OnlyAdminRejoinAsSpectator=true                            # Uncomment to only allow admins to rejoin as spectator
+#arkflag_DisableDeathSpectator=true                                 # Uncomment to disable players from becoming spectators when they die
 
 # config Service
 servicename="arkserv"                                               # Name of the service (don't change if you don't know what are you doing)

--- a/tools/lsb/arkdaemon
+++ b/tools/lsb/arkdaemon
@@ -29,7 +29,7 @@ case "$1" in
   start)
     log_daemon_msg "Starting" "$NAME"
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON start" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON start --all" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -42,7 +42,7 @@ case "$1" in
 
   stop)
     log_daemon_msg "Stopping" "$NAME"
-    su -s /bin/sh -c "$DAEMON stop" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON stop --all" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -55,7 +55,7 @@ case "$1" in
 
   restart)
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON restart" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON restart --all" $steamcmd_user
   ;;
 
   status)

--- a/tools/openrc/arkdaemon
+++ b/tools/openrc/arkdaemon
@@ -15,7 +15,7 @@ depend(){
 start(){
     ebegin "Starting ARK manager daemon"
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON start" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON start --all" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -27,7 +27,7 @@ start(){
 
 stop(){
     ebegin "Stopping ARK manager daemon"
-    su -s /bin/sh -c "$DAEMON start" $steamcmd_user
+    su -s /bin/sh -c "$DAEMON stop --all" $steamcmd_user
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then

--- a/tools/redhat/arkdaemon
+++ b/tools/redhat/arkdaemon
@@ -43,7 +43,7 @@ case "$1" in
   start)
     echo -n "Starting $NAME: "
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON start" $steamcmd_user > /dev/null
+    su -s /bin/sh -c "$DAEMON start --all" $steamcmd_user > /dev/null
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -59,7 +59,7 @@ case "$1" in
 
   stop)
     echo -n "Stopping $NAME: "
-    su -s /bin/sh -c "$DAEMON stop" $steamcmd_user > /dev/null
+    su -s /bin/sh -c "$DAEMON stop --all" $steamcmd_user > /dev/null
     sleep 5
     PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
     if  [ -n "$PID" ];  then
@@ -76,7 +76,7 @@ case "$1" in
   restart)
     echo -n "Restarting $NAME: "
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON restart" $steamcmd_user > /dev/null
+    su -s /bin/sh -c "$DAEMON restart --all" $steamcmd_user > /dev/null
     echo "OK"
   ;;
 

--- a/tools/systemd/arkdeamon.service
+++ b/tools/systemd/arkdeamon.service
@@ -3,8 +3,8 @@ Description=Daemon to start ark server
 After=network.target
 
 [Service]
-ExecStart=/usr/libexec/arkmanager/arkmanager.init start
-ExecStop=/usr/libexec/arkmanager/arkmanager.init stop
+ExecStart=/usr/libexec/arkmanager/arkmanager.init start --all
+ExecStop=/usr/libexec/arkmanager/arkmanager.init stop --all
 Type=forking
 PIDFile=/var/run/arkmanager.pid
 


### PR DESCRIPTION
0080e3c adds support for starting / stopping multiple servers running on the same machine, by adding an `--all` option to start, stop and restart.

d6fc1f7 updates the init scripts to use the feature added in the above commit.

b294cb6 adds support for ARK flags (such as `-OnlyAdminRejoinAsSpectator`).

3eb123f adds example config options (commented out) to the config file.

544a782 adds support for the AltSaveDirectoryName ARK option when performing a backup.