### PR TITLE
Add option to warn players before update

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Apply update without check the current version
 #### arkmanager update --safe
 Waits for server to perform world save and then updates.
 
+#### arkmanager update --warn
+Warns the players for a configurable amount of time before updating.  Should be suitable for adding to a cron job.
+
 #### arkmanager status
 Get the status of the server. Show if the process is running, if the server is up and the current version number
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -554,6 +554,7 @@ doWarnUpdate(){
   if isUpdateNeeded; then
     local pid=`getServerPID`
     if [ -n "$pid" ]; then
+      local warnmsg
       local warnminutes=$(( arkwarnminutes ))
       if (( warnminutes == 0 )); then
         warnminutes=60
@@ -564,9 +565,15 @@ doWarnUpdate(){
       for warninterval in "${warnintervals[@]}"; do
         if [ "`getServerPID`" != "$pid" ]; then
           echo "Server has stopped.  Aborting update"
+          return 1
         fi
         if (( arkwarnminutes > warninterval )); then
-          doBroadcastWithEcho "This ARK server will shutdown for an update in $warnminutes minutes"
+          if [ -n "$msgWarnUpdateMinutes" ]; then
+            warnmsg="$(printf "$msgWarnUpdateMinutes" "$warnminutes")"
+          else
+            warnmsg="$(printf "This ARK server will shutdown for an update in %d minutes" "$warnminutes")"
+          fi
+          doBroadcastWithEcho "$warnmsg"
           sleep $(( warnminutes - warninterval ))m
           warnminutes=$warninterval
         fi
@@ -577,8 +584,14 @@ doWarnUpdate(){
       for warninterval in "${warnintervals[@]}"; do
         if [ "`getServerPID`" != "$pid" ]; then
           echo "Server has stopped.  Aborting update"
+          return 1
         fi
-        doBroadcastWithEcho "This ARK server will shutdown for an update in $warnseconds seconds"
+        if [ -n "$msgWarnUpdateMinutes" ]; then
+          warnmsg="$(printf "$msgWarnUpdateMinutes" "$warnminutes")"
+        else
+          warnmsg="$(printf "This ARK server will shutdown for an update in %d seconds" "$warnseconds")"
+        fi
+        doBroadcastWithEcho "$warnmsg"
         sleep $(( warnseconds - warninterval ))s
       done
     fi

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -12,6 +12,11 @@ arkserverexec="ShooterGame/Binaries/Linux/ShooterGameServer"        # name of AR
 arkbackupdir="/home/steam/ARK-Backups"                              # path to backup directory
 arkwarnminutes="60"                                                 # number of minutes to warn players when using update --warn
 
+# Update warning messages
+# Modify as desired, putting the %d replacement operator where the number belongs
+msgWarnUpdateMinutes="This ARK server will shutdown for an update in %d minutes"
+msgWarnUpdateSeconds="This ARK server will shutdown for an update in %d seconds"
+
 # ARK server options - use ark_<optionname>=<value>
 # comment out these values if you want to define them
 # inside your GameUserSettings.ini file


### PR DESCRIPTION
First, merge from master, resolving the conflict due to doInstallMod and doWarnUpdate being in the same place in the script

c0793a8 makes the update warning message customisable[en_UK]/customizable[en_US].

b0e41d0 adds `update --warn` to the list of commands in the readme.