### PR TITLE
Improve install and add uninstall script

### DIFF
--- a/netinstall.sh
+++ b/netinstall.sh
@@ -4,7 +4,9 @@
 # Net Installer, used with curl
 #
 
+steamcmd_user="$1"
 channel=${2:-master} # if defined by 2nd argument install the defined version, otherwise install master
+shift 2
 
 # Download and untar installation files
 cd /tmp
@@ -33,7 +35,7 @@ sed -i "s|^arkstCommit='.*'$|arkstCommit='${COMMIT}'|" arkmanager
 version=`<../.version`
 sed -i "s|^arkstVersion=\".*\"|arkstVersion='${version}'|" arkmanager
 chmod +x install.sh
-bash install.sh $1 > /dev/null
+bash install.sh "$steamcmd_user" "$@" > /dev/null
 
 status=$?
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1015,6 +1015,25 @@ doUpgrade() {
   fi
 }
 
+doUninstallTools() {
+  local sudo=sudo
+  if [ "$steamcmd_user" == "--me" ]; then
+    sudo=
+  fi
+
+  read -p "Are you sure you want to uninstall the ARK Server Tools?" -n 1 -r
+
+  if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+    if [ -n "${install_datadir}" -a -x "${install_datadir}/arkmanager-uninstall.sh" ]; then
+      $sudo "${install_datadir}/arkmanager-uninstall.sh"
+      exit 0
+    elif [ -n "${install_libexecdir}" -a -x "${install_libexecdir}/arkmanager-uninstall.sh" ]; then
+      $sudo "${install_libexecdir}/arkmanager-uninstall.sh"
+      exit 0
+    fi
+  fi
+}
+
 useConfig() {
   for varname in "${!configfile_@}"; do
     if [ "configfile_$1" == "$varname" ]; then
@@ -1107,6 +1126,9 @@ while true; do
     upgrade-tools)
       doUpgrade
     ;;
+    uninstall-tools)
+      doUninstallTools
+    ;;
     useconfig)
       useConfig "$2"
       shift
@@ -1135,6 +1157,7 @@ while true; do
       echo "update --validate     Validates all ARK server files"
       echo "update --update-mods  Updates installed and requested mods"
       echo "upgrade-tools         Check for a new ARK Server Tools version and upgrades it if needed"
+      echo "uninstall-tools       Uninstall the ARK Server Tools"
       echo "useconfig <name>      Use the configuration overrides in the specified config name or file"
       exit 1
     ;;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1104,7 +1104,7 @@ while true; do
     status)
       printStatus
     ;;
-    upgrade)
+    upgrade-tools)
       doUpgrade
     ;;
     useconfig)
@@ -1134,7 +1134,7 @@ while true; do
       echo "update --warn         Warn players before updating server"
       echo "update --validate     Validates all ARK server files"
       echo "update --update-mods  Updates installed and requested mods"
-      echo "upgrade               Check for a new ARK Server Tools version and upgrades it if needed"
+      echo "upgrade-tools         Check for a new ARK Server Tools version and upgrades it if needed"
       echo "useconfig <name>      Use the configuration overrides in the specified config name or file"
       exit 1
     ;;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -48,6 +48,12 @@ arkautorestartfile="${arkautorestartfile:-ShooterGame/Saved/.autorestart}"
 install_bindir="${install_bindir:-${0%/*}}"
 install_libexecdir="${install_libexecdir:-${install_bindir%/*}/libexec/arkmanager}"
 
+if [ "$steamcmd_user" == "--me" ]; then
+  install_datadir="${install_datadir:-${HOME}/.share/local/arkmanager}"
+else
+  install_datadir="${install_datadir:-${install_bindir%/*}/share/arkmanager}"
+fi
+
 # Script version
 arkstVersion="1.3"
 arkstCommit=''
@@ -984,6 +990,9 @@ doUpgrade() {
   fi
   if [ -n "$install_libexecdir" ]; then
     reinstall_args=( "${reinstall_args[@]}" "--libexecdir" "$install_libexecdir" )
+  fi
+  if [ -n "$install_datadir" ]; then
+    reinstall_args=( "${reinstall_args[@]}" "--datadir" "$install_datadir" )
   fi
   if [[ $arkstLatestVersion > $arkstVersion ]]; then
     read -p "A new version was found! Do you want to upgrade ARK Server Tools to v${arkstLatestVersion}?" -n 1 -r

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -45,6 +45,8 @@ arkserverLog="arkserver.log"    # here is logged the output of ShooterGameServer
 appid="${appid:-376030}"
 mod_appid="${mod_appid:-346110}"
 arkautorestartfile="${arkautorestartfile:-ShooterGame/Saved/.autorestart}"
+install_bindir="${install_bindir:-${0%/*}}"
+install_libexecdir="${install_libexecdir:-${install_bindir%/*}/libexec/arkmanager}"
 
 # Script version
 arkstVersion="1.3"
@@ -976,11 +978,18 @@ doUpgrade() {
   echo "arkmanager v${arkstVersion}: Checking for updates..."
   arkstLatestVersion=`curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/.version`
   arkstLatestCommit=`curl -s https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads/${arkstChannel} | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`
+  reinstall_args=()
+  if [ -n "$install_bindir" ]; then
+    reinstall_args=( "${reinstall_args[@]}" "--bindir" "$install_bindir" )
+  fi
+  if [ -n "$install_libexecdir" ]; then
+    reinstall_args=( "${reinstall_args[@]}" "--libexecdir" "$install_libexecdir" )
+  fi
   if [[ $arkstLatestVersion > $arkstVersion ]]; then
     read -p "A new version was found! Do you want to upgrade ARK Server Tools to v${arkstLatestVersion}?" -n 1 -r
     echo -en "\n"
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-        curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s -- ${steamcmd_user} ${arkstChannel}
+        curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s -- ${steamcmd_user} ${arkstChannel} "${reinstall_args[@]}"
       else
         exit 0
     fi
@@ -988,7 +997,7 @@ doUpgrade() {
     read -p "A hotfix is available for v${arkstLatestVersion}.  Do you wish to install it?" -n 1 -r
     echo -en "\n"
     if [[ $REPLY =~ ^[Yy]$ ]]; then
-        curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s -- ${steamcmd_user} ${arkstChannel}
+        curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s -- ${steamcmd_user} ${arkstChannel} "${reinstall_args[@]}"
       else
         exit 0
     fi

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -1,6 +1,7 @@
 arkstChannel="master"                                               # change it to a different branch to get non-stable versions
 install_bindir="/usr/bin"
 install_libexecdir="/usr/libexec/arkmanager"
+install_datadir="/usr/share/arkmanager"
 
 # config SteamCMD
 steamcmdroot="/home/steam/steamcmd"                                 # path of your steamcmd instance

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -1,4 +1,6 @@
 arkstChannel="master"                                               # change it to a different branch to get non-stable versions
+install_bindir="/usr/bin"
+install_libexecdir="/usr/libexec/arkmanager"
 
 # config SteamCMD
 steamcmdroot="/home/steam/steamcmd"                                 # path of your steamcmd instance

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -78,7 +78,8 @@ if [ "$userinstall" == "yes" ]; then
   PREFIX="${PREFIX:-${HOME}}"
   EXECPREFIX="${EXECPREFIX:-${PREFIX}}"
 else
-  EXECPREFIX="${EXECPREFIX:-/usr/local}"
+  PREFIX="${PREFIX:-/usr/local}"
+  EXECPREFIX="${EXECPREFIX:-${PREFIX}}"
 fi
 
 BINDIR="${BINDIR:-${EXECPREFIX}/bin}"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -129,6 +129,8 @@ if [ "$userinstall" == "yes" ]; then
     sed -i -e "s|^steamcmd_user=\"steam\"|steamcmd_user=\"--me\"|" \
            -e "s|\"/home/steam|\"${PREFIX}|" \
            -e "s|/var/log/arktools|${PREFIX}/logs/arktools|" \
+           -e "s|^install_bindir=.*|install_bindir=\"${BINDIR}\"|" \
+           -e "s|^install_libexecdir=.*|install_libexecdir=\"${LIBEXECDIR}\"|" \
            "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
 
     # Copy arkmanager.cfg to ~/.arkmanager.cfg if it doesn't already exist
@@ -229,6 +231,8 @@ else
     chown "$1" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
     sed -i -e "s|^steamcmd_user=\"steam\"|steamcmd_user=\"$1\"|" \
            -e "s|\"/home/steam|\"/home/$1|" \
+           -e "s|^install_bindir=.*|install_bindir=\"${BINDIR}\"|" \
+           -e "s|^install_libexecdir=.*|install_libexecdir=\"${LIBEXECDIR}\"|" \
            "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
 
     if [ -f "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg" ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -123,16 +123,21 @@ if [ "$userinstall" == "yes" ]; then
     # Create a folder in ~/logs to let Ark tools write its own log files
     mkdir -p "${INSTALL_ROOT}${PREFIX}/logs/arktools"
 
+    # Copy arkmanager.cfg to ~/.arkmanager.cfg.NEW
+    cp arkmanager.cfg "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
+    # Change the defaults in the new config file
+    sed -i -e "s|^steamcmd_user=\"steam\"|steamcmd_user=\"--me\"|" \
+           -e "s|\"/home/steam|\"${PREFIX}|" \
+           -e "s|/var/log/arktools|${PREFIX}/logs/arktools|" \
+           "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
+
     # Copy arkmanager.cfg to ~/.arkmanager.cfg if it doesn't already exist
     if [ -f "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg" ]; then
-      cp -n arkmanager.cfg "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
-      sed -i "s|^steamcmd_user=\"steam\"|steamcmd_user=\"--me\"|;s|\"/home/steam|\"${PREFIX}|;s|/var/log/arktools|${PREFIX}/logs/arktools|" "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
       echo "A copy of the new configuration file was included in '${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW'. Make sure to review any changes and update your config accordingly!"
       exit 2
     else
-      cp -n arkmanager.cfg "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
-      sed -i "s|^steamcmd_user=\"steam\"|steamcmd_user=\"--me\"|;s|\"/home/steam|\"${PREFIX}|;s|/var/log/arktools|${PREFIX}/logs/arktools|" "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
+      mv -n "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW" "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
     fi
 else
     # Copy arkmanager to /usr/bin and set permissions
@@ -220,16 +225,18 @@ else
 
     # Copy arkmanager.cfg inside linux configuation folder if it doesn't already exists
     mkdir -p "${INSTALL_ROOT}/etc/arkmanager"
+    cp arkmanager.cfg "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
+    chown "$1" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
+    sed -i -e "s|^steamcmd_user=\"steam\"|steamcmd_user=\"$1\"|" \
+           -e "s|\"/home/steam|\"/home/$1|" \
+           "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
+
     if [ -f "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg" ]; then
-      cp -n arkmanager.cfg "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
-      chown "$1" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
       echo "A copy of the new configuration file was included in /etc/arkmanager. Make sure to review any changes and update your config accordingly!"
       exit 2
     else
-      cp -n arkmanager.cfg "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
-      chown "$1" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
-      sed -i "s|^steamcmd_user=\"steam\"|steamcmd_user=\"$1\"|;s|\"/home/steam|\"/home/$1|" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
+      mv -n "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
     fi
 fi
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -42,6 +42,13 @@ while [ -n "$1" ]; do
       BINDIR="$2"
       shift
     ;;
+    --libexecdir=*)
+      LIBEXECDIR="${1#--libexecdir=}"
+    ;;
+    --libexecdir)
+      LIBEXECDIR="$2"
+      shift
+    ;;
     -*)
       echo "Invalid option '$1'"
       showusage=yes
@@ -83,6 +90,7 @@ else
 fi
 
 BINDIR="${BINDIR:-${EXECPREFIX}/bin}"
+LIBEXECDIR="${LIBEXECDIR:-${EXECPREFIX}/libexec/arkmanager}"
 
 if [ "$showusage" == "yes" ]; then
     echo "Usage: ./install.sh {<user>|--me} [OPTIONS]"
@@ -102,6 +110,7 @@ if [ "$showusage" == "yes" ]; then
     echo "                [INSTALL_ROOT=${INSTALL_ROOT}]"
     echo "--bindir        Specify the directory under which to install executables"
     echo "                [BINDIR=${BINDIR}]"
+    echo "--libexecdir    Specify the directory under which to install executable support files"
     exit 1
 fi
 
@@ -134,12 +143,12 @@ else
     if [ -f /lib/lsb/init-functions ]; then
       # on debian 8, sysvinit and systemd are present. If systemd is available we use it instead of sysvinit
       if [ -f /etc/systemd/system.conf ]; then   # used by systemd
-        mkdir -p "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager"
-        cp lsb/arkdaemon "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
-        chmod +x "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+        mkdir -p "${INSTALL_ROOT}${LIBEXECDIRPREFIX}"
+        cp lsb/arkdaemon "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+        chmod +x "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-        sed -i "s|=/usr/|=${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-        sed -i "s@^DAEMON=\"/usr/bin/@DAEMON=\"${BINDIR}/@" "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+        sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        sed -i "s@^DAEMON=\"/usr/bin/@DAEMON=\"${BINDIR}/@" "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         if [ -z "${INSTALL_ROOT}" ]; then
           systemctl daemon-reload
           systemctl enable arkmanager.service
@@ -160,12 +169,12 @@ else
     elif [ -f /etc/rc.d/init.d/functions ]; then
       # on RHEL 7, sysvinit and systemd are present. If systemd is available we use it instead of sysvinit
       if [ -f /etc/systemd/system.conf ]; then   # used by systemd
-        mkdir -p "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager"
-        cp redhat/arkdaemon "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
-        chmod +x "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+        mkdir -p "${INSTALL_ROOT}${LIBEXECDIR}"
+        cp redhat/arkdaemon "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+        chmod +x "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-        sed -i "s|=/usr/|=${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-        sed -i "s@^DAEMON=\"/usr/bin/@DAEMON=\"${BINDIR}/@" "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+        sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        sed -i "s@^DAEMON=\"/usr/bin/@DAEMON=\"${BINDIR}/@" "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         if [ -z "${INSTALL_ROOT}" ]; then
           systemctl daemon-reload
           systemctl enable arkmanager.service
@@ -192,12 +201,12 @@ else
         echo "rc-update del arkmanager default"
       fi
     elif [ -f /etc/systemd/system.conf ]; then   # used by systemd
-      mkdir -p "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager"
-      cp systemd/arkdaemon.init "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
-      chmod +x "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+      mkdir -p "${INSTALL_ROOT}${LIBEXECDIR}"
+      cp systemd/arkdaemon.init "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+      chmod +x "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
       cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-      sed -i "s|=/usr/|=${EXECPREFIX}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-      sed -i "s@^DAEMON=\"/usr/bin/@DAEMON=\"${BINDIR}/@" "${INSTALL_ROOT}${EXECPREFIX}/libexec/arkmanager/arkmanager.init"
+      sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+      sed -i "s@^DAEMON=\"/usr/bin/@DAEMON=\"${BINDIR}/@" "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
       if [ -z "${INSTALL_ROOT}" ]; then
         systemctl enable arkmanager.service
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -14,6 +14,27 @@ while [ -n "$1" ]; do
       showusage=yes
       break
     ;;
+    --prefix=*)
+      PREFIX="${1#--prefix=}"
+    ;;
+    --prefix)
+      PREFIX="$2"
+      shift
+    ;;
+    --exec-prefix=*)
+      EXECPREFIX="${1#--exec-prefix=}"
+    ;;
+    --exec-prefix)
+      EXECPREFIX="$2"
+      shift
+    ;;
+    --install-root=*)
+      INSTALL_ROOT="${1#--install-root=}"
+    ;;
+    --install-root)
+      INSTALL_ROOT="$2"
+      shift
+    ;;
     -*)
       echo "Invalid option '$1'"
       showusage=yes

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -142,6 +142,16 @@ if [ "$userinstall" == "yes" ]; then
     cp arkmanager "${INSTALL_ROOT}${BINDIR}/arkmanager"
     chmod +x "${INSTALL_ROOT}${BINDIR}/arkmanager"
 
+    # Create a folder in ~/.local/share to store arkmanager support files
+    mkdir -p "${INSTALL_ROOT}${DATADIR}"
+
+    # Copy the uninstall script to ~/.local/share/arkmanager
+    cp uninstall-user.sh "${INSTALL_ROOT}${DATADIR}/arkmanager-uninstall.sh"
+    chmod +x "${INSTALL_ROOT}${DATADIR}/arkmanager-uninstall.sh"
+    sed -i -e "s|^BINDIR=.*|BINDIR=\"${BINDIR}\"|" \
+           -e "s|^DATADIR=.*|DATADIR=\"${DATADIR}\"|" \
+           "${INSTALL_ROOT}${DATADIR}/arkmanager-uninstall.sh"
+
     # Create a folder in ~/logs to let Ark tools write its own log files
     mkdir -p "${INSTALL_ROOT}${PREFIX}/logs/arktools"
 
@@ -168,6 +178,15 @@ else
     # Copy arkmanager to /usr/bin and set permissions
     cp arkmanager "${INSTALL_ROOT}${BINDIR}/arkmanager"
     chmod +x "${INSTALL_ROOT}${BINDIR}/arkmanager"
+
+    # Copy the uninstall script to ~/.local/share/arkmanager
+    mkdir -p "${INSTALL_ROOT}${LIBEXECDIR}"
+    cp uninstall.sh "${INSTALL_ROOT}${DATADIR}/arkmanager-uninstall.sh"
+    chmod +x "${INSTALL_ROOT}${DATADIR}/arkmanager-uninstall.sh"
+    sed -i -e "s|^BINDIR=.*|BINDIR=\"${BINDIR}\"|" \
+           -e "s|^LIBEXECDIR=.*|LIBEXECDIR=\"${LIBEXECDIR}\"|" \
+           -e "s|^DATADIR=.*|DATADIR=\"${DATADIR}\"|" \
+           "${INSTALL_ROOT}${DATADIR}/arkmanager-uninstall.sh"
 
     # Copy arkdaemon to /etc/init.d ,set permissions and add it to boot
     if [ -f /lib/lsb/init-functions ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -28,6 +28,13 @@ while [ -n "$1" ]; do
       EXECPREFIX="$2"
       shift
     ;;
+    --data-prefix=*)
+      DATAPREFIX="${1#--data-prefix=}"
+    ;;
+    --data-prefix)
+      DATAPREFIX="$2"
+      shift
+    ;;
     --install-root=*)
       INSTALL_ROOT="${1#--install-root=}"
     ;;
@@ -47,6 +54,13 @@ while [ -n "$1" ]; do
     ;;
     --libexecdir)
       LIBEXECDIR="$2"
+      shift
+    ;;
+    --datadir=*)
+      DATADIR="${1#--datadir=}"
+    ;;
+    --datadir)
+      DATADIR="$2"
       shift
     ;;
     -*)
@@ -84,13 +98,16 @@ fi
 if [ "$userinstall" == "yes" ]; then
   PREFIX="${PREFIX:-${HOME}}"
   EXECPREFIX="${EXECPREFIX:-${PREFIX}}"
+  DATAPREFIX="${DATAPREFIX:-${PREFIX}/.local/share}"
 else
   PREFIX="${PREFIX:-/usr/local}"
   EXECPREFIX="${EXECPREFIX:-${PREFIX}}"
+  DATAPREFIX="${DATAPREFIX:-${PREFIX}/share}"
 fi
 
 BINDIR="${BINDIR:-${EXECPREFIX}/bin}"
 LIBEXECDIR="${LIBEXECDIR:-${EXECPREFIX}/libexec/arkmanager}"
+DATADIR="${DATADIR:-${DATAPREFIX}/arkmanager}"
 
 if [ "$showusage" == "yes" ]; then
     echo "Usage: ./install.sh {<user>|--me} [OPTIONS]"
@@ -106,11 +123,16 @@ if [ "$showusage" == "yes" ]; then
     echo "                [PREFIX=${PREFIX}]"
     echo "--exec-prefix   Specify the prefix under which to install executables"
     echo "                [EXECPREFIX=${EXECPREFIX}]"
+    echo "--data-prefix   Specify the prefix under which to install suppor files"
+    echo "                [DATAPREFIX=${DATAPREFIX}]"
     echo "--install-root  Specify the staging directory in which to perform the install"
     echo "                [INSTALL_ROOT=${INSTALL_ROOT}]"
     echo "--bindir        Specify the directory under which to install executables"
     echo "                [BINDIR=${BINDIR}]"
     echo "--libexecdir    Specify the directory under which to install executable support files"
+    echo "                [LIBEXECDIR=${LIBEXECDIR}]"
+    echo "--datadir       Specify the directory under which to install support files"
+    echo "                [DATADIR=${DATADIR}]"
     exit 1
 fi
 
@@ -131,6 +153,7 @@ if [ "$userinstall" == "yes" ]; then
            -e "s|/var/log/arktools|${PREFIX}/logs/arktools|" \
            -e "s|^install_bindir=.*|install_bindir=\"${BINDIR}\"|" \
            -e "s|^install_libexecdir=.*|install_libexecdir=\"${LIBEXECDIR}\"|" \
+           -e "s|^install_datadir=.*|install_datadir=\"${DATADIR}\"|" \
            "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
 
     # Copy arkmanager.cfg to ~/.arkmanager.cfg if it doesn't already exist
@@ -233,6 +256,7 @@ else
            -e "s|\"/home/steam|\"/home/$1|" \
            -e "s|^install_bindir=.*|install_bindir=\"${BINDIR}\"|" \
            -e "s|^install_libexecdir=.*|install_libexecdir=\"${LIBEXECDIR}\"|" \
+           -e "s|^install_datadir=.*|install_datadir=\"${DATADIR}\"|" \
            "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
 
     if [ -f "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg" ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -75,15 +75,21 @@ else
 fi
 
 if [ "$showusage" == "yes" ]; then
+    echo "Usage: ./install.sh {<user>|--me} [OPTIONS]"
     echo "You must specify your system steam user who own steamcmd directory to install ARK Tools."
     echo "Specify the special used '--me' to perform a user-install."
-    echo "Usage: ./install.sh steam"
     echo
-    echo "Environment variables affecting install:"
-    echo "EXECPREFIX:   prefix in which to install arkmanager executable"
-    echo "              [${EXECPREFIX}]"
-    echo "INSTALL_ROOT: staging directory in which to perform install"
-    echo "              [${INSTALL_ROOT}]"
+    echo "<user>          The user arkmanager should be run as"
+    echo
+    echo "Option          Description"
+    echo "--help, -h      Show this help text"
+    echo "--me            Perform a user-install"
+    echo "--prefix        Specify the prefix under which to install arkmanager"
+    echo "                [PREFIX=${PREFIX}]"
+    echo "--exec-prefix   Specify the prefix under which to install executables"
+    echo "                [EXECPREFIX=${EXECPREFIX}]"
+    echo "--install-root  Specify the staging directory in which to perform the install"
+    echo "                [INSTALL_ROOT=${INSTALL_ROOT}]"
     exit 1
 fi
 

--- a/tools/uninstall-user.sh
+++ b/tools/uninstall-user.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# uninstall-user.sh
+
+BINDIR="/home/steam/bin"
+DATADIR="/home/steam/.local/share/arkmanager"
+
+for f in "${BINDIR}/arkmanager" \
+         "${DATADIR}/uninstall.sh"
+do
+  if [ -f "$f" ]; then
+    rm "$f"
+  fi
+done

--- a/tools/uninstall.sh
+++ b/tools/uninstall.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# uninstall.sh
+
+BINDIR="/usr/bin"
+DATADIR="/usr/share/arkmanager"
+LIBEXECDIR="/usr/libexec/arkmanager"
+INITSCRIPT=
+
+if [ -f "/etc/rc.d/init.d/arkmanager" ]; then
+  INITSCRIPT="/etc/rc.d/init.d/arkmanager"
+  if [ -f "/etc/rc.d/init.d/functions" ]; then
+    chkconfig arkmanager off
+  fi
+elif [ -f "/etc/init.d/arkmanager" ]; then
+  INITSCRIPT="/etc/init.d/arkmanager"
+  if [ -f "/lib/lsb/init-functions" ]; then
+    update-rc.d -f arkmanager remove
+  elif [ -f "/sbin/runscript" ]; then
+    rc-update del arkmanager default
+  fi
+elif [ -f "/etc/systemd/system/arkmanager.service" ]; then
+  INITSCRIPT="/etc/systemd/system/arkmanager.service"
+  systemctl disable arkmanager.service
+fi
+
+if [ -n "$INITSCRIPT" ]; then
+  for f in "${INITSCRIPT}" \
+           "${BINDIR}/arkmanager" \
+           "${LIBEXECDIR}/arkmanager.init" \
+           "${LIBEXECDIR}/arkmanager-uninstall.sh"
+  do
+    if [ -f "$f" ]; then
+      rm "$f"
+    fi
+  done
+fi


### PR DESCRIPTION
First merge in the hotfixes from the master branch.

The first few commits set the installer script up to handle upgrades better, and make options more discoverable.

37014ec adds better argument handling to the install script.

563c34b adds command-line arguments to the install script for the `PREFIX`, `EXECPREFIX` and `INSTALL_ROOT` distro-helper variables.

f597644 improves the installer script usage message.

b86967c adds a `BINDIR` variable and associated command-line argument to the installer script

3977190 adds the `PREFIX` variable to the global install

bfca58c adds a `LIBEXECDIR` variable and associated command-line argument to the installer script

d40d9d9 always writes the `arkmanager.cfg.NEW` file, and moves it to `arkmanager.cfg` if that file doesn't exist.

283c04d adds settings for the `BINDIR` and `LIBEXECDIR` to the config file, so they can be used when upgrading, and tries to guess them from the executable path if they're not set.

f878976 adds `DATAPREFIX` (i.e. `/usr/share`) and `DATADIR` (i.e. `/usr/share/arkmanager`) variables and their associated arguments to the installer.  This can be used for any static ancillary files - an example might be translations.

2a3a2cc adds uninstall scripts (`uninstall.sh` for a global uninstall, and `uninstall-user.sh` for a user-install uninstall) and sets them up using the installer script.  For user-installs, this is put into `$DATADIR`, which is `~/.local/share/arkmanager` by default.

0a09613 renames the `upgrade` command to `upgrade-tools`.  This should satisfy #115 

ee32f7c adds an `uninstall-tools` command, which runs the uninstall script after asking if the user really wants to uninstall the ARK server tools.  This plus 2a3a2cc should satisfy #140