### PR TITLE
Allow backing up prior to updating the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Validates all ARK server files
 #### arkmanager update --update-mods
 Updates installed and requested mods
 
+#### arkmanager update --backup
+Takes a backup of the save files before updating.
+
 #### arkmanager status
 Get the status of the server. Show if the process is running, if the server is up and the current version number
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -639,6 +639,9 @@ doUpdate() {
     doStop
 
     if [ -n "$appupdate" ]; then
+      if [ "$arkBackupPreUpdate" == "true" ]; then
+        doBackup
+      fi
       cd "$steamcmdroot"
       ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid $validate +quit
       # the current version should be the last version. We set our version

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1180,6 +1180,7 @@ while true; do
       echo "       --validate     Validates all ARK server files"
       echo "       --saveworld    Saves world before update"
       echo "       --update-mods  Updates installed and requested mods"
+      echo "       --backup       Takes a backup of the save files before updating"
       exit 1
     ;;
     *)

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -592,6 +592,8 @@ doUpdate() {
       saveworld=1
     elif [ "$arg" == "--update-mods" ]; then
       modupdate=1
+    elif [ "$arg" == "--backup" ]; then
+      arkBackupPreUpdate=true
     fi
   done
 
@@ -637,11 +639,14 @@ doUpdate() {
     fi
 
     doStop
+    
+    # If user wants to back-up, we do it here.
+    
+    if [ "$arkBackupPreUpdate" == "true" ]; then
+        doBackup
+    fi
 
     if [ -n "$appupdate" ]; then
-      if [ "$arkBackupPreUpdate" == "true" ]; then
-        doBackup
-      fi
       cd "$steamcmdroot"
       ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid $validate +quit
       # the current version should be the last version. We set our version
@@ -657,7 +662,7 @@ doUpdate() {
         fi
       done
     fi
-
+    
     # we restart the server only if it was started before the update
     if [ $serverWasAlive -eq 1 ]; then
       doStart

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -15,6 +15,7 @@ arkserverexec="ShooterGame/Binaries/Linux/ShooterGameServer"        # name of AR
 arkbackupdir="/home/steam/ARK-Backups"                              # path to backup directory
 arkwarnminutes="60"                                                 # number of minutes to warn players when using update --warn
 arkautorestartfile="ShooterGame/Saved/.autorestart"                 # path to autorestart file
+arkBackupPreUpdate="false"                                          # set this to true if you want to perform a backup before updating
 
 # Update warning messages
 # Modify as desired, putting the %d replacement operator where the number belongs


### PR DESCRIPTION
Two simple commits to make life easier with these frequent updates to ARK.

* Controllable by true/false in the configuration files.
* Only performs a backup if there actually is a new version available.