### PR TITLE
Allow empty options

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -316,6 +316,8 @@ doRun() {
 
     if [ -n "$val" ]; then
       arkserveropts="${arkserveropts}?${name}=${val}"
+    else
+      arkserveropts="${arkserveropts}?${name}"
     fi
   done
 


### PR DESCRIPTION
The config option e.g. ark_bRawSockets="" should result in the
...?bRawSockets

This should help resolve #178