### PR TITLE
Allow empty options

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -428,6 +428,8 @@ doRun() {
 
     if [ -n "$val" ]; then
       arkserveropts="${arkserveropts}?${name}=${val}"
+    else
+      arkserveropts="${arkserveropts}?${name}"
     fi
   done
 


### PR DESCRIPTION
Merge from the 1.3 hotfix.

The config option e.g. ark_bRawSockets="" should result in the
...?bRawSockets

This should help resolve #178 on 1.4-dev