### PR TITLE
Fix error in running as root

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -70,7 +70,7 @@ doUninstallTools() {
 
 runAsRoot(){
   getConfigVar(){
-    val="$(echo -ne "$(sed -n "/^$1=/{s|^[^=]*||;s|^\"\\(.*\\)\"\$|\\1|;s|^'\\(.*\\)\$|\\1|;p}" <"/etc/arkmanager/arkmanager.cfg" | tail -n1)")"
+    val="$(echo -ne "$(sed -n "/^$1=/{s|^[^=]*=||;s|[[:space:]]*\(#.*\)*\$||;s|^\"\\(.*\\)\"\$|\\1|;s|^'\\(.*\\)'\$|\\1|;p}" <"/etc/arkmanager/arkmanager.cfg" | tail -n1)")"
     if [ -n "$val" ]; then
       echo "$val"
     else

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -94,16 +94,7 @@ runAsRoot(){
   elif [ "$1" == "uninstall-tools" ]; then
     doUninstallTools
   else
-    echo -n "arkmanager v${arkstVersion}: "
-    if [ $# -eq 0 ]; then
-      echo "no command specified"
-    else
-      echo "unknown command '$1' specified"
-    fi
-    echo -e "Usage: arkmanager [OPTION]\n"
-    echo "Option                Description"
-    echo "upgrade-tools         Check for a new ARK Server Tools version and upgrades it if needed"
-    echo "uninstall-tools       Uninstall the ARK Server Tools"
+    su "$steamcmd_user" -c "$(printf "%q" "$0")$(printf " %q" "$@")"
     exit 1
   fi
 }


### PR DESCRIPTION
Running arkmanager as root in order to upgrade without sudo wasn't working - it would say that the steamcmd user was invalid.  a307643 fixes this.

1505aa8 runs any other commands as the steamcmd_user when arkmanager is run as root.