### PR TITLE
Add option to select mod OS

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -828,10 +828,17 @@ isModUpdateNeeded(){
   local modid=$1
   local modsrcdir="$steamcmdroot/steamapps/workshop/content/$mod_appid/$modid"
   local moddestdir="$arkserverroot/ShooterGame/Content/Mods/$modid"
+  local modbranch="${mod_branch:-Linux}"
+
+  for varname in "${!mod_branch_@}"; do
+    if [ "mod_branch_$modid" == "$varname" ]; then
+      modbranch="${!varname}"
+    fi
+  done
 
   if [ -f "$modsrcdir/mod.info" ]; then
-    if [ -f "$modsrcdir/LinuxNoEditor/mod.info" ]; then
-      modsrcdir="$modsrcdir/LinuxNoEditor"
+    if [ -f "$modsrcdir/${modbranch}NoEditor/mod.info" ]; then
+      modsrcdir="$modsrcdir/${modbranch}NoEditor"
     fi
 
     find "$modsrcdir" -type f ! -name "*.z.uncompressed_size" -printf "%P\n" | while read f; do
@@ -864,11 +871,19 @@ doExtractMod(){
   local modid=$1
   local modsrcdir="$steamcmdroot/steamapps/workshop/content/$mod_appid/$modid"
   local moddestdir="$arkserverroot/ShooterGame/Content/Mods/$modid"
+  local modbranch="${mod_branch:-Linux}"
+
+  for varname in "${!mod_branch_@}"; do
+    if [ "mod_branch_$modid" == "$varname" ]; then
+      modbranch="${!varname}"
+    fi
+  done
 
   if [ -f "$modsrcdir/mod.info" ]; then
     echo "Copying files to $moddestdir"
-    if [ -f "$modsrcdir/LinuxNoEditor/mod.info" ]; then
-      modsrcdir="$modsrcdir/LinuxNoEditor"
+
+    if [ -f "$modsrcdir/${modbranch}NoEditor/mod.info" ]; then
+      modsrcdir="$modsrcdir/${modbranch}NoEditor"
     fi
 
     find "$modsrcdir" -type d -printf "$moddestdir/%P\0" | xargs -0 -r mkdir -p

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -51,6 +51,11 @@ logdir="/var/log/arktools"                                          # Logs path 
 appid=376030                                                        # Linux server App ID
 mod_appid=346110                                                    # App ID for mods
 
+# Mod OS Selection
+mod_branch=Linux
+# Add mod-specific OS selection below:
+#mod_branch_496735411=Windows
+
 # alternate configs
 # example for config name "ark1":
 #configfile_ark1="/path/to/config/file"


### PR DESCRIPTION
The Linux version of some mods don't work at all with the dedicated
server.  Allow the administrator to configure which mod branch
to grab (Windows or Linux).

This should fix #196 