### PR TITLE
1.4 enhancements

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -434,6 +434,15 @@ doRun() {
     fi
   done
 
+  # bring in arkopt_... options
+  for varname in "${!arkopt_@}"; do
+    name="${varname#arkopt_}"
+    val="${!varname}"
+
+    if [ -n "$val" ]; then
+      arkextraopts=( "${arkextraopts[@]}" "-${name}=${val}" )
+    fi
+  done
 
   arkserveropts="${arkserveropts}?listen"
   # run the server in background

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -837,6 +837,10 @@ isModUpdateNeeded(){
     fi
   done
 
+  if [ \( ! -f "$moddestdir/.modbranch" \) ] || [ "$(<"$moddestdir/.modbranch")" != "$modbranch" ]; then
+    return 0
+  fi
+
   if [ -f "$modsrcdir/mod.info" ]; then
     if [ -f "$modsrcdir/${modbranch}NoEditor/mod.info" ]; then
       modsrcdir="$modsrcdir/${modbranch}NoEditor"
@@ -872,13 +876,17 @@ doExtractMod(){
   local modid=$1
   local modsrcdir="$steamcmdroot/steamapps/workshop/content/$mod_appid/$modid"
   local moddestdir="$arkserverroot/ShooterGame/Content/Mods/$modid"
-  local modbranch="${mod_branch:-Linux}"
+  local modbranch="${mod_branch:-Windows}"
 
   for varname in "${!mod_branch_@}"; do
     if [ "mod_branch_$modid" == "$varname" ]; then
       modbranch="${!varname}"
     fi
   done
+
+  if [ \( ! -f "$moddestdir/.modbranch" \) ] || [ "$(<"$moddestdir/.modbranch")" != "$modbranch" ]; then
+    rm -rf "$moddestdir"
+  fi
 
   if [ -f "$modsrcdir/mod.info" ]; then
     echo "Copying files to $moddestdir"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -466,6 +466,9 @@ doRun() {
 
   # Auto-restart loop
   while [ $restartserver -ne 0 ]; do
+    echo -n "`timestamp`: Running"
+    printf " %q" "$arkserverroot/$arkserverexec" "$arkserveropts" "${arkextraopts[@]}"
+    echo
     # Put the server process into the background so we can monitor it
     "$arkserverroot/$arkserverexec" "$arkserveropts" "${arkextraopts[@]}" &
     # Grab the server PID

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -354,7 +354,7 @@ function getCurrentVersion(){
 #
 function getAvailableVersion(){
   rm -f "$steamcmd_appinfocache"
-  bnumber=`$steamcmdroot/$steamcmdexec +login anonymous +app_info_update 1 +app_info_print "$appid" +quit | while read name val; do if [ "${name}" == "{" ]; then parseSteamACF ".depots.branches.public" "buildid"; break; fi; done`
+  bnumber=`$steamcmdroot/$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +app_info_update 1 +app_info_print "$appid" +quit | while read name val; do if [ "${name}" == "{" ]; then parseSteamACF ".depots.branches.public" "buildid"; break; fi; done`
   return $bnumber
 }
 
@@ -605,7 +605,7 @@ doInstall() {
 
   cd "$steamcmdroot"
   # install the server
-  ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid validate +quit
+  ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkserverroot" +app_update $appid validate +quit
   # the current version should be the last version. We set our version
   getCurrentVersion
 }
@@ -749,7 +749,7 @@ doUpdate() {
 
     if [ -n "$appupdate" ]; then
       cd "$steamcmdroot"
-      ./$steamcmdexec +login anonymous +force_install_dir "$arkserverroot" +app_update $appid $validate +quit
+      ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkserverroot" +app_update $appid $validate +quit
       # the current version should be the last version. We set our version
       getCurrentVersion
       echo "`timestamp`: update to $instver complete" >> "$logdir/update.log"
@@ -797,7 +797,7 @@ doDownloadMod(){
   cd "$steamcmdroot"
 
   while true; do
-    ./$steamcmdexec +login anonymous +workshop_download_item $mod_appid $modid +quit
+    ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +workshop_download_item $mod_appid $modid +quit
     if [ ! -d "$moddldir" ]; then break; fi
     local newsize="`du -s "$moddldir" | cut -f1`"
     if [ $newsize -eq $dlsize ]; then break; fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -427,11 +427,8 @@ doRun() {
   # bring in arkflag_... flags
   for varname in "${!arkflag_@}"; do
     name="${varname#arkflag_}"
-    val="${!varname}"
 
-    if [ -n "$val" ]; then
-      arkextraopts=( "${arkextraopts[@]}" "-${name}" )
-    fi
+    arkextraopts=( "${arkextraopts[@]}" "-${name}" )
   done
 
   # bring in arkopt_... options

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -52,7 +52,7 @@ appid=376030                                                        # Linux serv
 mod_appid=346110                                                    # App ID for mods
 
 # Mod OS Selection
-mod_branch=Linux
+mod_branch=Windows
 # Add mod-specific OS selection below:
 #mod_branch_496735411=Windows
 

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -8,6 +8,7 @@ steamcmdroot="/home/steam/steamcmd"                                 # path of yo
 steamcmdexec="steamcmd.sh"                                          # name of steamcmd executable
 steamcmd_user="steam"                                               # name of the system user who own steamcmd folder
 steamcmd_appinfocache="/home/steam/Steam/appcache/appinfo.vdf"      # cache of the appinfo command
+#steamlogin="anonymous"                                             # Uncomment this to specify steam login instead of using anonymous login
 
 # config environment
 arkserverroot="/home/steam/ARK"                                     # path of your ARK server files (default ~/ARK)

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -44,6 +44,9 @@ ark_MaxPlayers="70"
 #arkflag_OnlyAdminRejoinAsSpectator=true                            # Uncomment to only allow admins to rejoin as spectator
 #arkflag_DisableDeathSpectator=true                                 # Uncomment to disable players from becoming spectators when they die
 
+# ARK server options - i.e. for -optname=val, use arkopt_optname=val
+#arkopt_StructureDestructionTag=DestroySwampSnowStructures
+
 # config Service
 servicename="arkserv"                                               # Name of the service (don't change if you don't know what are you doing)
 logdir="/var/log/arktools"                                          # Logs path (default /var/log/arktools)


### PR DESCRIPTION
e4d4218 changes the default mod branch to be Windows, and records the current mod branch in a `.modbranch` file in the mod directory.  If the requested mod branch doesn't match the current mod branch, then the mod is removed and re-added.  This should fix #196.

167781e adds non-anonymous steamcmd login, using the `steamlogin=user` option in the arkmanager config file.  This should fix #205.

17dd16a adds support for options of the form `-opt=val`, by specifying `arkopt_opt=val` in the arkmanager config file.  This should fix #204.

d27eff2 logs the command that is used to launch the server, which should make it easier for the user to verify what commandline is used and to launch the server separately from ARK Server Tools.

fa7649d allow the user to specify `arkflag_<optname>=""` - e.g. `arkflag_log=""`