### PR TITLE
Check Query port when determining if server is up

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -393,6 +393,30 @@ function isTheServerRunning(){
 function isTheServerUp(){
   $lsof -i :"$ark_Port" > /dev/null
   result=$?
+  if [ $result -ne 0 ]; then
+    perl -MSocket -MFcntl -e '
+      my $port = int($ARGV[0]);
+      socket(my $socket, PF_INET, SOCK_DGRAM, 0);
+      setsockopt($socket, SOL_SOCKET, SO_RCVTIMEO, pack("i4", 1, 0, 0, 0));
+      my $sockaddr = pack_sockaddr_in($port, inet_aton("127.0.0.1"));
+      send($socket, "\xff\xff\xff\xffTSource Engine Query\x00", 0, $sockaddr);
+      my $flags = fcntl($socket, F_GETFL, 0) or exit(1);
+      fcntl($socket, F_SETFL, $flags | O_NONBLOCK) or exit(1);
+      my $data = "";
+      my $rin = "";
+      vec($rin, fileno($socket), 1) = 1;
+      if (select($rin, undef, undef, 0.25) >= 0) {
+        recv($socket, $data, 1400, 0) or exit(1);
+        my ($servername, $mapname, $game, $fullname, $rest) = split(/\x00/, substr($data, 6), 5);
+        my $maxplayers = ord(substr($rest, 3, 1));
+        if ($maxplayers == 0) { exit(1); }
+        exit(0);
+      } else {
+        exit(1);
+      }
+      ' "${ark_QueryPort}"
+    result=$?
+  fi
   # In this case, the result is:
   # 1 if the command fail. The port is not listenning
   # 0 if the command succeed. The port is listenning


### PR DESCRIPTION
This should resolve the case where the server shows as down, due to kernel patches, or due to lsof being broken or not being installed.

This queries the server, and if it responds with a non-zero MaxPlayers value, then it reports the server as being up.