### PR TITLE
Remove mod id from from workshop acf on installmod

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -993,6 +993,10 @@ doExtractMod(){
 doInstallMod(){
   local modid=$1
 
+  if [ -f "$steamcmdroot/steamapps/workshop/appworkshop_${mod_appid}.acf" ]; then
+    sed -i "/^\\t\\t\"${modid}\"/,/^\\t\\t}/d" "$steamcmdroot/steamapps/workshop/appworkshop_${mod_appid}.acf"
+  fi
+
   if doDownloadMod $modid; then
     doExtractMod $modid
     echo "Mod $modid installed"


### PR DESCRIPTION
This removes the mod from the `appworkshop_${mod_appid}.acf` when attempting a mod install, as steamcmd will cache that a mod download failed, and will return `File Not Found` when attempting to fetch the mod again, even if the steam login now has access to the mod.

This should resolve #205.