### PR TITLE
1.4 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ ark_DifficultyOffset=1
 Your session name may not contain special characters (eg. `!![EU]!! Aw&some ARK`) as it could break the startup command.  
 In this case you may want to comment out the `ark_SessionName` variable and define it inside your **GameUserSettings.ini** file instead.
 
+To specify an option without an argument (e.g. `bRawSockets`), specify an empty argument (e.g. `ark_bRawSockets=""`).
+
+To specify a dash-option without an argument (e.g. `-log`), add the option="" prefixed with `arkflag_` (e.g. `arkflag_log=""`).
+
+To specify a dash-option with an argument (e.g. `-StructureDestructionTag=DestroySwampSnowStructures`), add the option=value prefixed with `arkopt_` (e.g. `arkopt_StructureDestructionTag=DestroySwampSnowStructures`).
+
 You can override or add variables for a specific system user creating a file called `.arkmanager.cfg` in the home directory of the system user.
 
 ## Install ARK Server

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ NB: You may want to change the `bash -s` parameter to fit your steam user if dif
 
 This will copy the `arkmanager` script and its daemon to the proper directories and will create an empty log directory in `/var/log` for ARK Server Tools.
 
+To instead perform a user-install of ARK Server Tools as an unprivileged user, run this command:
+
+```sh
+curl -sL http://git.io/vtf5N | bash -s -- --me
+```
+
 ## Configuration
 
 Stored in `/etc/arkmanager/arkmanager.cfg` you can find the variables needed to start the server, like the port numbers, the system environment variables and so on.
@@ -80,24 +86,25 @@ Stops ARK server
 Restarts ARK server
 
 #### arkmanager update
-Manually updates ARK server if a new version is available
+Manually updates ARK server if a new version is available.
+This accepts zero or more of the below options.
 
-#### arkmanager update --force
+##### arkmanager update --force
 Apply update without check the current version
 
-#### arkmanager update --safe
+##### arkmanager update --safe
 Waits for server to perform world save and then updates.
 
-#### arkmanager update --warn
+##### arkmanager update --warn
 Warns the players for a configurable amount of time before updating.  Should be suitable for adding to a cron job.
 
-#### arkmanager update --validate
+##### arkmanager update --validate
 Validates all ARK server files
 
-#### arkmanager update --update-mods
+##### arkmanager update --update-mods
 Updates installed and requested mods
 
-#### arkmanager update --backup
+##### arkmanager update --backup
 Takes a backup of the save files before updating.
 
 #### arkmanager status

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -311,12 +311,11 @@ function checkForUpdate(){
 function isUpdateNeeded(){
   getCurrentVersion
   getAvailableVersion
-  if [ "$bnumber" -eq "$instver" ]; then
+  if [ "$bnumber" = "Unknown" -o "$bnumber" -eq "$instver" ]; then
     return 1   # no update needed
   else
     return 0   # update needed
   fi
-
 }
 
 #
@@ -365,6 +364,9 @@ function getCurrentVersion(){
 function getAvailableVersion(){
   rm -f "$steamcmd_appinfocache"
   bnumber=`$steamcmdroot/$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +app_info_update 1 +app_info_print "$appid" +quit | while read name val; do if [ "${name}" == "{" ]; then parseSteamACF ".depots.branches.public" "buildid"; break; fi; done`
+  if [ -z "$bnumber" ]; then
+    bnumber="Unknown"
+  fi
   return $bnumber
 }
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1037,6 +1037,10 @@ doExtractMod(){
 doInstallMod(){
   local modid=$1
 
+  if [ -f "$steamcmdroot/steamapps/workshop/appworkshop_${mod_appid}.acf" ]; then
+    sed -i "/^\\t\\t\"${modid}\"/,/^\\t\\t}/d" "$steamcmdroot/steamapps/workshop/appworkshop_${mod_appid}.acf"
+  fi
+
   if doDownloadMod $modid; then
     doExtractMod $modid
     echo "Mod $modid installed"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -393,6 +393,30 @@ function isTheServerRunning(){
 function isTheServerUp(){
   $lsof -i :"$ark_Port" > /dev/null
   result=$?
+  if [ $result -ne 0 ]; then
+    perl -MSocket -MFcntl -e '
+      my $port = int($ARGV[0]);
+      socket(my $socket, PF_INET, SOCK_DGRAM, 0);
+      setsockopt($socket, SOL_SOCKET, SO_RCVTIMEO, pack("i4", 1, 0, 0, 0));
+      my $sockaddr = pack_sockaddr_in($port, inet_aton("127.0.0.1"));
+      send($socket, "\xff\xff\xff\xffTSource Engine Query\x00", 0, $sockaddr);
+      my $flags = fcntl($socket, F_GETFL, 0) or exit(1);
+      fcntl($socket, F_SETFL, $flags | O_NONBLOCK) or exit(1);
+      my $data = "";
+      my $rin = "";
+      vec($rin, fileno($socket), 1) = 1;
+      if (select($rin, undef, undef, 0.25) >= 0) {
+        recv($socket, $data, 1400, 0) or exit(1);
+        my ($servername, $mapname, $game, $fullname, $rest) = split(/\x00/, substr($data, 6), 5);
+        my $maxplayers = ord(substr($rest, 3, 1));
+        if ($maxplayers == 0) { exit(1); }
+        exit(0);
+      } else {
+        exit(1);
+      }
+      ' "${ark_QueryPort}"
+    result=$?
+  fi
   # In this case, the result is:
   # 1 if the command fail. The port is not listenning
   # 0 if the command succeed. The port is listenning


### PR DESCRIPTION
e2f8a3e should resolve the case where the server shows as down, due to kernel patches, or due to lsof being broken or not being installed.  This queries the server, and if it responds with a non-zero MaxPlayers value, then it reports the server as being up.

01edcab This removes the mod from the appworkshop_${mod_appid}.acf when attempting a mod install, as steamcmd will cache that a mod download failed, and will return File Not Found when attempting to fetch the mod again, even if the steam login now has access to the mod.  This should resolve #205.

f8699b4 adds mention of the `--me` install option in the readme, and mentions that the `update` command accepts multiple options.

9052c46 adds mention in the readme of the following option types in the config:

* ark_option="" -> ...?option?...
* arkflag_option="" -> -option
* arkopt_option=val -> -option=val

0e6dfc2 prevents arkmanager from reporting an update is available if steamcmd fails to return a result from the `app_info_print` command - previously it would report an update was available even if none was available.  This should resolve #220.