### PR TITLE
1.4 fixes

### DIFF
--- a/netinstall.sh
+++ b/netinstall.sh
@@ -44,7 +44,7 @@ rm -rf /tmp/ark-server-tools-${channel}
 # Print messages
 case "$status" in
   "0")
-    echo "ARK Server Tools were correctly installed in your system inside the home directory of $1!"
+    echo "ARK Server Tools were correctly installed in your system inside the home directory of $steamcmd_user!"
     ;;
 
   "1")
@@ -52,6 +52,6 @@ case "$status" in
     ;;
   "2")
     echo "WARNING: A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
-    echo "ARK Server Tools were correctly installed in your system inside the home directory of $1!"
+    echo "ARK Server Tools were correctly installed in your system inside the home directory of $steamcmd_user!"
     ;;
 esac

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -311,7 +311,7 @@ function checkForUpdate(){
 function isUpdateNeeded(){
   getCurrentVersion
   getAvailableVersion
-  if [ "$bnumber" = "Unknown" -o "$bnumber" -eq "$instver" ]; then
+  if [[ "$bnumber" == "Unknown" || "$bnumber" -eq "$instver" ]]; then
     return 1   # no update needed
   else
     return 0   # update needed
@@ -355,7 +355,6 @@ function getCurrentVersion(){
   else
     instver=""
   fi
-  return $instver
 }
 
 #
@@ -367,7 +366,6 @@ function getAvailableVersion(){
   if [ -z "$bnumber" ]; then
     bnumber="Unknown"
   fi
-  return $bnumber
 }
 
 #

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -43,7 +43,6 @@ doUpgradeTools() {
     echo -en "\n"
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s -- ${steamcmd_user} ${arkstChannel} "${reinstall_args[@]}"
-      else
         exit 0
     fi
   elif [[ $arkstLatestVersion == $arkstVersion && "$arkstLatestCommit" != "$arkstCommit" ]]; then
@@ -51,7 +50,6 @@ doUpgradeTools() {
     echo -en "\n"
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s -- ${steamcmd_user} ${arkstChannel} "${reinstall_args[@]}"
-      else
         exit 0
     fi
   else

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -213,11 +213,12 @@ else
       # on debian 8, sysvinit and systemd are present. If systemd is available we use it instead of sysvinit
       if [ -f /etc/systemd/system.conf ]; then   # used by systemd
         mkdir -p "${INSTALL_ROOT}${LIBEXECDIR}"
-        cp lsb/arkdaemon "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+        cp systemd/arkmanager.init "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         chmod +x "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
-        cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        cp systemd/arkmanager.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-        sed -i "s@^DAEMON=\"/usr/bin/@DAEMON=\"${BINDIR}/@" "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+        cp systemd/arkmanager@.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
+        sed -i "s|=/usr/bin/|=${BINDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         if [ -z "${INSTALL_ROOT}" ]; then
           systemctl daemon-reload
           systemctl enable arkmanager.service
@@ -239,11 +240,12 @@ else
       # on RHEL 7, sysvinit and systemd are present. If systemd is available we use it instead of sysvinit
       if [ -f /etc/systemd/system.conf ]; then   # used by systemd
         mkdir -p "${INSTALL_ROOT}${LIBEXECDIR}"
-        cp redhat/arkdaemon "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+        cp systemd/arkmanager.init "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         chmod +x "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
-        cp systemd/arkdeamon.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
+        cp systemd/arkmanager.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
-        sed -i "s@^DAEMON=\"/usr/bin/@DAEMON=\"${BINDIR}/@" "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+        cp systemd/arkmanager@.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
+        sed -i "s|=/usr/bin/|=${BINDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         if [ -z "${INSTALL_ROOT}" ]; then
           systemctl daemon-reload
           systemctl enable arkmanager.service
@@ -278,6 +280,7 @@ else
       cp systemd/arkmanager@.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
       sed -i "s|=/usr/bin/|=${BINDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
       if [ -z "${INSTALL_ROOT}" ]; then
+        systemctl daemon-reload
         systemctl enable arkmanager.service
         echo "Ark server will now start on boot, if you want to remove this feature run the following line"
         echo "systemctl disable arkmanager.service"


### PR DESCRIPTION
aeafb3f fixes 0e6dfc2 to actually not report an update available if steam is unreachable - `test -o` apparently doesn't short-circuit.

The next 3 commits should resolve #231.

1165dc1 updates the installer script to match the new systemd scripts.

b2e0414 fixes the "ARK Server Tools were correctly installed" messages in netinstaller.sh to use `$steamcmd_user`, since `$1` will be the first extra argument that was passed to the installer.

29b952e exits arkmanager after an upgrade, instead of when an upgrade is denied.