### PR TITLE
Fix error in MultiHome support

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -390,7 +390,7 @@ function isTheServerRunning(){
 #
 #
 function isTheServerUp(){
-  $lsof -i "udp@${ark_MultiHome}:${ark_Port}" > /dev/null
+  $lsof -i "${ark_MultiHome:+udp@}${ark_MultiHome}:${ark_Port}" > /dev/null
   result=$?
   if [ $result -ne 0 ]; then
     perl -MSocket -MFcntl -e '


### PR DESCRIPTION
I discovered an error in the MultiHome support added in #235, where lsof errors out when MultiHome is not used.  This should fix that error.