### PR TITLE
Set TERM to "dumb" if TERM is not set

### DIFF
--- a/tools/systemd/arkdaemon.init
+++ b/tools/systemd/arkdaemon.init
@@ -20,6 +20,9 @@
 #
 ### END INIT INFO
 
+# Set TERM to "dumb" if TERM is not set
+export TERM=${TERM:-dumb}
+
 # Global variables
 source /etc/arkmanager/arkmanager.cfg
 


### PR DESCRIPTION
Set environment variable TERM to "dumb" if it is not set. This suppresses errors from "tput", which are shown in eg. "systemctl status arkmanager.service". The error which tput gives without TERM set is "tput: No value for $TERM and no -T specified".