### PR TITLE
Pull #241 from master into 1.4-dev

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -39,6 +39,9 @@ YELLOW="\\e[0;33m"
 NORMAL="\\033[0;39m"
 maxOpenFiles=100000
 
+# Set TERM to "dumb" if TERM is not set
+export TERM=${TERM:-dumb}
+
 arkmanagerLog="arkmanager.log"  # here are logged the actions performed by arkmanager
 arkserverLog="arkserver.log"    # here is logged the output of ShooterGameServer
 

--- a/tools/systemd/arkdaemon.init
+++ b/tools/systemd/arkdaemon.init
@@ -20,9 +20,6 @@
 #
 ### END INIT INFO
 
-# Set TERM to "dumb" if TERM is not set
-export TERM=${TERM:-dumb}
-
 # Global variables
 source /etc/arkmanager/arkmanager.cfg
 


### PR DESCRIPTION
Moves the `export TERM="${TERM:-dumb}"` fix in #241 from tools/systemd/arkdaemon.init to tools/arkmanager

This should also clean up the conflict that currently prevents 1.4-dev from being merged into master, so we can stabilize v1.4