### PR TITLE
Fix error causing netinstall to fail with one argument

### DIFF
--- a/netinstall.sh
+++ b/netinstall.sh
@@ -6,7 +6,8 @@
 
 steamcmd_user="$1"
 channel=${2:-master} # if defined by 2nd argument install the defined version, otherwise install master
-shift 2
+shift
+shift
 
 # Download and untar installation files
 cd /tmp


### PR DESCRIPTION
`shift 2` will fail to shift off any arguments if there are less than 2 arguments.
Convert `shift 2` to two separate `shift` statements.

This should resolve #248