### PR TITLE
Fix mod update not being detected

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -917,11 +917,11 @@ isModUpdateNeeded(){
       modsrcdir="$modsrcdir/${modbranch}NoEditor"
     fi
 
-    find "$modsrcdir" -type f ! -name "*.z.uncompressed_size" -printf "%P\n" | while read f; do
+    while read f; do
       if [ \( ! -f "$moddestdir/${f%.z}" \) -o "$modsrcdir/$f" -nt "$moddestdir/${f%.z}" ]; then
         return 0
       fi
-    done
+    done < <(find "$modsrcdir" -type f ! -name "*.z.uncompressed_size" -printf "%P\n")
   fi
 
   return 1


### PR DESCRIPTION
A mistake in `isModUpdateNeeded` was causing the test for new or updated files to be run as a subprocess, and the result of that was not being passed up.  This switches it around so the file listing is passed through using process substitution.  This should fix #257