### PR TITLE
Fix typo in `upgrade-tools` when running as root

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -98,7 +98,7 @@ runAsRoot(){
   fi
 
   if [ "$1" == "upgrade-tools" ]; then
-    doUpgrade
+    doUpgradeTools
   elif [ "$1" == "uninstall-tools" ]; then
     doUninstallTools
   else


### PR DESCRIPTION
This fixes a typo in the `upgrade-tools` command when running as root.  This should resolve #258.