### PR TITLE
Add support for downloading updates before applying

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -942,11 +942,15 @@ doDownloadMod(){
   cd "$steamcmdroot"
 
   while true; do
+    echo "Downloading mod $modid"
     runSteamCMD +workshop_download_item $mod_appid $modid
+    echo
+    echo "Checking mod $modid"
     if [ ! -d "$moddldir" ]; then break; fi
     local newsize="`du -s "$moddldir" | cut -f1`"
     if [ $newsize -eq $dlsize ]; then break; fi
     dlsize=$newsize
+    echo "Mod $modid not fully downloaded - retrying"
   done
 
   if [ -f "$modsrcdir/mod.info" ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -286,6 +286,13 @@ doBroadcastWithEcho(){
 }
 
 #
+# SteamCMD helper function
+#
+function runSteamCMD(){
+  "$steamcmdroot/$steamcmdexec" +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} "$@" +quit
+}
+
+#
 # Check if a new version is available but not apply it
 #
 function checkForUpdate(){
@@ -364,7 +371,7 @@ function getCurrentVersion(){
 #
 function getAvailableVersion(){
   rm -f "$steamcmd_appinfocache"
-  bnumber=`$steamcmdroot/$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +app_info_update 1 +app_info_print "$appid" +quit | while read name val; do if [ "${name}" == "{" ]; then parseSteamACF ".depots.branches.public" "buildid"; break; fi; done`
+  bnumber=`runSteamCMD +app_info_update 1 +app_info_print "$appid" +quit | while read name val; do if [ "${name}" == "{" ]; then parseSteamACF ".depots.branches.public" "buildid"; break; fi; done`
   if [ -z "$bnumber" ]; then
     bnumber="Unknown"
   fi
@@ -660,6 +667,13 @@ doStopAll(){
 }
 
 #
+# install / update / download update
+#
+runSteamCMDAppUpdate(){
+  runSteamCMD +force_install_dir "$1" +app_update $appid $2
+}
+
+#
 # install of ARK server
 #
 doInstall() {
@@ -676,7 +690,7 @@ doInstall() {
 
   cd "$steamcmdroot"
   # install the server
-  ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkserverroot" +app_update $appid validate +quit
+  runSteamCMDAppUpdate "$arkserverroot" validate
   # the current version should be the last version. We set our version
   getCurrentVersion
 }
@@ -812,7 +826,7 @@ doUpdate() {
 
       echo "Downloading ARK update"
       cd "$steamcmdroot"
-      ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkStagingDir" +app_update $appid $validate +quit
+      runSteamCMDAppUpdate "$arkStagingDir" $validate
       if [ -d "${arkStagingDir}/steamapps/downloading/${appid}" ]; then
         echo "Update download interrupted"
         return 1
@@ -878,7 +892,7 @@ doUpdate() {
       else
         echo "Performing ARK update"
         cd "$steamcmdroot"
-        ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkserverroot" +app_update $appid $validate +quit
+	runSteamCMDAppUpdate "$arkserverroot" $validate
       fi
       # the current version should be the last version. We set our version
       getCurrentVersion
@@ -928,7 +942,7 @@ doDownloadMod(){
   cd "$steamcmdroot"
 
   while true; do
-    ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +workshop_download_item $mod_appid $modid +quit
+    runSteamCMD +workshop_download_item $mod_appid $modid
     if [ ! -d "$moddldir" ]; then break; fi
     local newsize="`du -s "$moddldir" | cut -f1`"
     if [ $newsize -eq $dlsize ]; then break; fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -767,7 +767,7 @@ doUpdate() {
       modupdate=1
     elif [ "$arg" == "--backup" ]; then
       arkBackupPreUpdate=true
-    elif [ "$arg" =~ "^--stagingdir=" ]; then
+    elif [[ "$arg" =~ "^--stagingdir=" ]]; then
       arkStagingDir="${ark#--stagingdir=}"
     elif [ "$arg" == "--downloadonly" ]; then
       downloadonly=1

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -771,6 +771,10 @@ doUpdate() {
       arkStagingDir="${ark#--stagingdir=}"
     elif [ "$arg" == "--downloadonly" ]; then
       downloadonly=1
+    else
+      echo "Unrecognized option $arg"
+      echo "Try 'arkmanager -h' or 'arkmanager --help' for more information."
+      exit 1
     fi
   done
 
@@ -790,6 +794,7 @@ doUpdate() {
 
     if [ -n "${arkStagingDir}" -a "${arkStagingDir}" != "${arkserverroot}" ]; then
       if [ ! -d "$arkStagingDir/ShooterGame" ]; then
+        echo "Copying to staging directory"
         mkdir -p "$arkStagingDir"
         if [ "$(stat -c "%d" "$arkserverroot")" == "$(stat -c "%d" "$arkStagingDir")" ]; then
           cp -al "$arkserverroot/ShooterGame/." "$arkStagingDir/ShooterGame"
@@ -805,6 +810,7 @@ doUpdate() {
         rm -rf "$arkStagingDir/ShooterGame/Saved/"*
       fi
 
+      echo "Downloading ARK update"
       cd "$steamcmdroot"
       ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkStagingDir" +app_update $appid $validate +quit
       if [ -d "${arkStagingDir}/steamapps/downloading/${appid}" ]; then
@@ -858,6 +864,7 @@ doUpdate() {
 
     if [ -n "$appupdate" ]; then
       if [ -d "${arkStagingDir}" -a "${arkStagingDir}" != "${arkserverroot}" ]; then
+        echo "Applying update from staging directory"
         if [ "$(stat -c "%d" "$arkserverroot")" == "$(stat -c "%d" "$arkStagingDir")" ]; then
           cp -alu --remove-destination "$arkStagingDir/ShooterGame/." "$arkserverroot/ShooterGame"
           cp -alu --remove-destination "$arkStagingDir/Engine/." "$arkserverroot/Engine"
@@ -869,6 +876,7 @@ doUpdate() {
           rsync -a "$arkStagingDir/." "$arkserverroot"
         fi
       else
+        echo "Performing ARK update"
         cd "$steamcmdroot"
         ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkserverroot" +app_update $appid $validate +quit
       fi
@@ -880,6 +888,7 @@ doUpdate() {
     if [ -n "$modupdate" ]; then
       for modid in $(getModIds); do
         if isModUpdateNeeded $modid; then
+          echo "Updating mod $modid"
           doExtractMod $modid
           echo "`timestamp`: Mod $modid updated" >> "$logdir/update.log"
         fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -790,12 +790,17 @@ doUpdate() {
 
     if [ -n "${arkStagingDir}" -a "${arkStagingDir}" != "${arkserverroot}" ]; then
       if [ ! -d "$arkStagingDir/ShooterGame" ]; then
-        cp -al "$arkserverroot/ShooterGame/." "$arkStagingDir/ShooterGame"
-        cp -al "$arkserverroot/Engine/." "$arkStagingDir/Engine"
-        cp -al "$arkserverroot/linux64/." "$arkStagingDir/linux64"
-        cp -al "$arkserverroot/PackageInfo.bin" "$arkStagingDir/PackageInfo.bin"
-        cp -al "$arkserverroot/steamclient.so" "$arkStagingDir/steamclient.so"
-        cp -a "$arkserverroot/steamapps/." "$arkStagingDir/steamapps"
+        mkdir -p "$arkStagingDir"
+        if [ "$(stat -c "%d" "$arkserverroot")" == "$(stat -c "%d" "$arkStagingDir")" ]; then
+          cp -al "$arkserverroot/ShooterGame/." "$arkStagingDir/ShooterGame"
+          cp -al "$arkserverroot/Engine/." "$arkStagingDir/Engine"
+          cp -al "$arkserverroot/linux64/." "$arkStagingDir/linux64"
+          cp -al "$arkserverroot/PackageInfo.bin" "$arkStagingDir/PackageInfo.bin"
+          cp -al "$arkserverroot/steamclient.so" "$arkStagingDir/steamclient.so"
+          cp -a "$arkserverroot/steamapps/." "$arkStagingDir/steamapps"
+        else
+          rsync -a "$arkserverroot/." "$arkStagingDir/."
+        fi
         rm -rf "$arkStagingDir/ShooterGame/Content/Mods/"*
         rm -rf "$arkStagingDir/ShooterGame/Saved/"*
       fi
@@ -853,12 +858,16 @@ doUpdate() {
 
     if [ -n "$appupdate" ]; then
       if [ -d "${arkStagingDir}" -a "${arkStagingDir}" != "${arkserverroot}" ]; then
-        cp -alu --remove-destination "$arkStagingDir/ShooterGame/." "$arkserverroot/ShooterGame"
-        cp -alu --remove-destination "$arkStagingDir/Engine/." "$arkserverroot/Engine"
-        cp -alu --remove-destination "$arkStagingDir/linux64/." "$arkserverroot/linux64"
-        cp -alu --remove-destination "$arkStagingDir/PackageInfo.bin" "$arkserverroot/PackageInfo.bin"
-        cp -alu --remove-destination "$arkStagingDir/steamclient.so" "$arkserverroot/steamclient.so"
-        cp -au --remove-destination "$arkStagingDir/steamapps/." "$arkserverroot/steamapps"
+        if [ "$(stat -c "%d" "$arkserverroot")" == "$(stat -c "%d" "$arkStagingDir")" ]; then
+          cp -alu --remove-destination "$arkStagingDir/ShooterGame/." "$arkserverroot/ShooterGame"
+          cp -alu --remove-destination "$arkStagingDir/Engine/." "$arkserverroot/Engine"
+          cp -alu --remove-destination "$arkStagingDir/linux64/." "$arkserverroot/linux64"
+          cp -alu --remove-destination "$arkStagingDir/PackageInfo.bin" "$arkserverroot/PackageInfo.bin"
+          cp -alu --remove-destination "$arkStagingDir/steamclient.so" "$arkserverroot/steamclient.so"
+          cp -au --remove-destination "$arkStagingDir/steamapps/." "$arkserverroot/steamapps"
+        else
+          rsync -a "$arkStagingDir/." "$arkserverroot"
+        fi
       else
         cd "$steamcmdroot"
         ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkserverroot" +app_update $appid $validate +quit

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -889,6 +889,18 @@ doUpdate() {
         else
           rsync -a "$arkStagingDir/." "$arkserverroot"
         fi
+        cd "$arkserverroot"
+        find Engine ShooterGame linux64 -depth -print |
+          grep -v '^ShooterGame/\(Saved\|Content/Mods\)' |
+          while read f; do
+            if [ ! -e "staging/${f}" ]; then
+              if [ -f "$f" ]; then
+                rm "${f}"
+              else
+                rmdir "${f}"
+              fi
+            fi
+          done
       else
         echo "Performing ARK update"
         cd "$steamcmdroot"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -749,6 +749,7 @@ doUpdate() {
   local validate=
   local modupdate=
   local saveworld=
+  local downloadonly=
 
   for arg in "$@"; do
     if [ "$arg" == "--force" ]; then
@@ -766,6 +767,10 @@ doUpdate() {
       modupdate=1
     elif [ "$arg" == "--backup" ]; then
       arkBackupPreUpdate=true
+    elif [ "$arg" =~ "^--stagingdir=" ]; then
+      arkStagingDir="${ark#--stagingdir=}"
+    elif [ "$arg" == "--downloadonly" ]; then
+      downloadonly=1
     fi
   done
 
@@ -782,9 +787,37 @@ doUpdate() {
 
   if isUpdateNeeded; then
     appupdate=1
+
+    if [ -n "${arkStagingDir}" -a "${arkStagingDir}" != "${arkserverroot}" ]; then
+      if [ ! -d "$arkStagingDir/ShooterGame" ]; then
+        cp -al "$arkserverroot/ShooterGame/." "$arkStagingDir/ShooterGame"
+        cp -al "$arkserverroot/Engine/." "$arkStagingDir/Engine"
+        cp -al "$arkserverroot/linux64/." "$arkStagingDir/linux64"
+        cp -al "$arkserverroot/PackageInfo.bin" "$arkStagingDir/PackageInfo.bin"
+        cp -al "$arkserverroot/steamclient.so" "$arkStagingDir/steamclient.so"
+        cp -a "$arkserverroot/steamapps/." "$arkStagingDir/steamapps"
+        rm -rf "$arkStagingDir/ShooterGame/Content/Mods/"*
+        rm -rf "$arkStagingDir/ShooterGame/Saved/"*
+      fi
+
+      cd "$steamcmdroot"
+      ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkStagingDir" +app_update $appid $validate +quit
+      if [ -d "${arkStagingDir}/steamapps/downloading/${appid}" ]; then
+        echo "Update download interrupted"
+        return 1
+      fi
+    fi
   fi
 
-  if [ -n "$appupdate" -o -n "$modupdate" ]; then
+  if [ -n "$downloadonly" ]; then
+    if [ -n "$appupdate" -a -n "$arkStagingDir" -a "$arkStagingDir" != "$arkserverroot" ]; then
+      echo "Server update downloaded"
+    fi
+    if [ -n "$modupdate" ]; then
+      echo "Mod update downloaded"
+    fi
+    echo "Not applying update - download-only enabled"
+  elif [ -n "$appupdate" -o -n "$modupdate" ]; then
     if isTheServerRunning; then
       if [ "$updatetype" == "safe" ]; then
         while [ ! `find $arkserverroot/ShooterGame/Saved/SavedArks -mmin -1 -name ${serverMap##*/}.ark` ]; do
@@ -811,16 +844,25 @@ doUpdate() {
     fi
 
     doStop
-    
+
     # If user wants to back-up, we do it here.
-    
+
     if [ "$arkBackupPreUpdate" == "true" ]; then
         doBackup
     fi
 
     if [ -n "$appupdate" ]; then
-      cd "$steamcmdroot"
-      ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkserverroot" +app_update $appid $validate +quit
+      if [ -d "${arkStagingDir}" -a "${arkStagingDir}" != "${arkserverroot}" ]; then
+        cp -alu --remove-destination "$arkStagingDir/ShooterGame/." "$arkserverroot/ShooterGame"
+        cp -alu --remove-destination "$arkStagingDir/Engine/." "$arkserverroot/Engine"
+        cp -alu --remove-destination "$arkStagingDir/linux64/." "$arkserverroot/linux64"
+        cp -alu --remove-destination "$arkStagingDir/PackageInfo.bin" "$arkserverroot/PackageInfo.bin"
+        cp -alu --remove-destination "$arkStagingDir/steamclient.so" "$arkserverroot/steamclient.so"
+        cp -au --remove-destination "$arkStagingDir/steamapps/." "$arkserverroot/steamapps"
+      else
+        cd "$steamcmdroot"
+        ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +force_install_dir "$arkserverroot" +app_update $appid $validate +quit
+      fi
       # the current version should be the last version. We set our version
       getCurrentVersion
       echo "`timestamp`: update to $instver complete" >> "$logdir/update.log"
@@ -834,7 +876,7 @@ doUpdate() {
         fi
       done
     fi
-    
+
     # we restart the server only if it was started before the update
     if [ $serverWasAlive -eq 1 ]; then
       doStart
@@ -1365,13 +1407,15 @@ while true; do
       echo "useconfig <name>      Use the configuration overrides in the specified config name or file"
       echo
       echo "Update command takes the below options:"
-      echo "       --force        Apply update without checking the current version"
-      echo "       --safe         Wait for server to perform world save and update."
-      echo "       --warn         Warn players before updating server"
-      echo "       --validate     Validates all ARK server files"
-      echo "       --saveworld    Saves world before update"
-      echo "       --update-mods  Updates installed and requested mods"
-      echo "       --backup       Takes a backup of the save files before updating"
+      echo "   --force            Apply update without checking the current version"
+      echo "   --safe             Wait for server to perform world save and update."
+      echo "   --warn             Warn players before updating server"
+      echo "   --validate         Validates all ARK server files"
+      echo "   --saveworld        Saves world before update"
+      echo "   --update-mods      Updates installed and requested mods"
+      echo "   --backup           Takes a backup of the save files before updating"
+      echo "   --downloadonly     Download the mod and/or server update without applying it"
+      echo "                      Requires arkStagingDir be set to a staging directory on the same filesystem as the server"
       exit 1
     ;;
     *)

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -18,6 +18,7 @@ arkwarnminutes="60"                                                 # number of 
 arkautorestartfile="ShooterGame/Saved/.autorestart"                 # path to autorestart file
 arkBackupPreUpdate="false"                                          # set this to true if you want to perform a backup before updating
 arkTimeToKeepBackupFiles="10"                                       #Set to Automatically Remove backups older than n days
+#arkStagingDir="/home/steam/ARK-Staging"                            # Uncomment to enable downloading updates before restarting the server
 
 # Update warning messages
 # Modify as desired, putting the %d replacement operator where the number belongs

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -18,7 +18,7 @@ arkwarnminutes="60"                                                 # number of 
 arkautorestartfile="ShooterGame/Saved/.autorestart"                 # path to autorestart file
 arkBackupPreUpdate="false"                                          # set this to true if you want to perform a backup before updating
 arkTimeToKeepBackupFiles="10"                                       #Set to Automatically Remove backups older than n days
-#arkStagingDir="/home/steam/ARK-Staging"                            # Uncomment to enable downloading updates before restarting the server
+#arkStagingDir="/home/steam/ARK-Staging"                            # Uncomment to enable updates to be fully downloaded before restarting the server (reduces downtime while updating)
 
 # Update warning messages
 # Modify as desired, putting the %d replacement operator where the number belongs


### PR DESCRIPTION
This downloads the update to a staging directory before initiating the shutdown warning and update.  This was requested in #237.

In order to save some space, this creates hard links to the files in the staging directory, relying on the fact that `steamcmd` doesn't modify files in-place, but rather downloads them to `steamapps/downloading/<appid>` then removes the old files and replaces them with the new files, and files outside `ShooterGame/Saved` are not modified by `ShooterGameServer`.

This space saving does require that `$arkserverroot` and `$arkStagingDir` are on the same filesystem.  If those are not on the same filesystem, then it will use `rsync` to copy the files.