### PR TITLE
Fix a couple of bugs in update --warn

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -714,14 +714,14 @@ doUpdateWarn(){
       warnminutes=60
     fi
 
-    local warnintervals=( 90 60 45 30 20 15 10 5 4 3 2 1 )
+    local warnintervals=( 90 60 45 30 20 15 10 5 4 3 2 )
 
     for warninterval in "${warnintervals[@]}"; do
       if [ "`getServerPID`" != "$pid" ]; then
         echo "Server has stopped.  Aborting update"
         return 1
       fi
-      if (( arkwarnminutes > warninterval )); then
+      if (( warnminutes > warninterval )); then
         sleep 1m &
         sleeppid=$!
         if [ -n "$msgWarnUpdateMinutes" ]; then
@@ -746,8 +746,8 @@ doUpdateWarn(){
       fi
     done
 
-    local warnseconds=90
-    warnintervals=( 60 45 30 20 15 10 5 0 )
+    local warnseconds=120
+    warnintervals=( 90 60 45 30 20 15 10 5 0 )
     for warninterval in "${warnintervals[@]}"; do
       sleep $(( warnseconds - warninterval ))s &
       sleeppid=$!


### PR DESCRIPTION
* Due to a bug in the minutes remaining check,
  the warning period was defaulting to 90 seconds,
  when it should have defaulted to 60 minutes.
* The time between 2 minutes and 90 seconds was
  60 seconds, when it should be 30 seconds