### PR TITLE
Add per-command multi-instance support

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1394,6 +1394,12 @@ printStatus(){
 }
 
 useConfig() {
+  if [ -f "/etc/arkmanager/instances/${1}.cfg" ]; then
+    source "/etc/arkmanager/instances/${1}.cfg"
+  fi
+  if [ -f "${HOME}/.config/arkmanager/instances/${1}.cfg" ]; then
+    source "${HOME}/.config/arkmanager/instances/${1}.cfg"
+  fi
   if [ "$1" == "main" ]; then
     return
   fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1393,6 +1393,41 @@ printStatus(){
   echo -e "$NORMAL" "Server version: " "$GREEN" $instver "$NORMAL"
 }
 
+getAllInstanceNames(){
+  declare -A instancenames
+  for varname in "${!configfile_@}"; do
+    instancename="${varname#configfile_}"
+    instancenames[${instancename}]="${instancename}"
+  done
+  for f in /etc/arkmanager/instances/*.cfg; do
+    if [ -f "${f}" ]; then
+      instancename="${f##*/}"
+      instancename="${instancename%.cfg}"
+      instancenames[${instancename}]="${instancename}"
+    fi
+  done
+  for f in ${HOME}/.config/arkmanager/instances/*.cfg; do
+    if [ -f "${f}" ]; then
+      instancename="${f##*/}"
+      instancename="${instancename%.cfg}"
+      instancenames[${instancename}]="${instancename}"
+    fi
+  done
+
+  echo "${instancenames[@]}"
+}
+
+doListAllInstances(){
+  echo "The following instances are available:"
+  for n in $(getAllInstanceNames); do
+    (
+      echo -n "  @${n}: "
+      useConfig "$n"
+      echo "${arkserverroot}"
+    )
+  done
+}
+
 useConfig() {
   if [ -f "/etc/arkmanager/instances/${1}.cfg" ]; then
     source "/etc/arkmanager/instances/${1}.cfg"
@@ -1422,6 +1457,7 @@ showUsage() {
   echo "Command               Description"
   echo "upgrade-tools         Check for a new ARK Server Tools version and upgrades it if needed"
   echo "uninstall-tools       Uninstall the ARK Server Tools"
+  echo "list-instances        Lists all available instances"
   echo
   echo "Commands that take one or more instances:"
   echo "Command               Description"
@@ -1478,8 +1514,13 @@ while [[ "$#" -gt 0 ]]; do
       doUninstallTools
       exit
     ;;
+    list-instances)
+      doListAllInstances
+      exit
+    ;;
     -h|--help)
       showUsage
+      exit
     ;;
   esac
 
@@ -1527,10 +1568,7 @@ while [[ "$#" -gt 0 ]]; do
 
   # Handle all instances being requested
   if [[ "$allinstances" == "yes" ]]; then
-    instances=( )
-    for varname in "${!configfile_@}"; do
-      instances+=( "${varname#configfile_}" )
-    done
+    instances=( $(getAllInstanceNames) )
   fi
 
   # Run the command for each instance requested

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1406,6 +1406,46 @@ useConfig() {
   source "$1"
 }
 
+showUsage() {
+  echo -e "Usage: arkmanager [Commands]\n"
+  echo "Commands can be followed by one or more @instance arguments"
+  echo "The special '@all' instance selects all instances"
+  echo "Commands may also be followed by zero or more --options"
+  echo
+  echo "Commands that take no instances:"
+  echo "Command               Description"
+  echo "upgrade-tools         Check for a new ARK Server Tools version and upgrades it if needed"
+  echo "uninstall-tools       Uninstall the ARK Server Tools"
+  echo
+  echo "Commands that take one or more instances:"
+  echo "Command               Description"
+  echo "backup                Saves a backup of your server inside the backup directory"
+  echo "broadcast <msg>       Sends a message to all users connected to server"
+  echo "saveworld             Saves the game world to disk"
+  echo "rconcmd <cmd>         Execute RCON command on server"
+  echo "checkupdate           Check for a new ARK server version"
+  echo "install               Install the ARK server files from steamcmd"
+  echo "installmod <modid>    Installs a mod from the Steam workshop"
+  echo "restart               Stops the server and then starts it"
+  echo "run                   Runs the server without daemonizing"
+  echo "start                 Starts the server"
+  echo "stop                  Stops the server"
+  echo "status                Returns the status of the current ARK server instance"
+  echo "update                Check for a new ARK server version, if needed, stops the server, updates it, and starts it again"
+  echo
+  echo "Update command takes the below options:"
+  echo "   --force            Apply update without checking the current version"
+  echo "   --safe             Wait for server to perform world save and update."
+  echo "   --warn             Warn players before updating server"
+  echo "   --validate         Validates all ARK server files"
+  echo "   --saveworld        Saves world before update"
+  echo "   --update-mods      Updates installed and requested mods"
+  echo "   --backup           Takes a backup of the save files before updating"
+  echo "   --downloadonly     Download the mod and/or server update without applying it"
+  echo "                      Requires arkStagingDir be set to a staging directory on the same filesystem as the server"
+  exit 1
+}
+
 #---------------------
 # Main program
 #---------------------
@@ -1413,139 +1453,151 @@ useConfig() {
 # check the configuration and throw errors or warnings if needed
 checkConfig
 
-while true; do
-  case "$1" in
-    run)
-        doRun
-    ;;
-    start)
-        if [ "$2" == "--all" ]; then
-          doStartAll
-          shift
-        else
-          doStart
-        fi
-    ;;
-    stop)
-        if [ "$2" == "--all" ]; then
-          doStopAll
-          shift
-        else
-          doStop
-        fi
-    ;;
-    restart)
-        if [ "$2" == "--all" ]; then
-	  doStopAll
-	else
-          doStop
-	fi
-        echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
-        sleep 1
-	if [ "$2" == "--all" ]; then
-          doStartAll
-	  shift
-	else
-	  doStart
-	fi
-        echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
-        echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"
-    ;;
-    install)
-        doInstall
-    ;;
-    update)
-        args=()
+while [[ "$#" -gt 0 ]]; do
+  options=( )
+  allinstances=no
+  instances=( )
+  args=( )
+  command="$1"
+  shift
+  nrarg=0
 
-	while [[ "$2" =~ ^-- ]]; do
-	  args=( "${args[@]}" "$2" )
-	  shift
-	done
-
-	doUpdate "${args[@]}"
-    ;;
-    checkupdate)
-      checkForUpdate
-    ;;
-    installmod)
-      doInstallMod "$2"
-      shift
-    ;;
-    backup)
-      doBackup
-    ;;
-    broadcast)
-      doBroadcast "$2"
-      shift
-    ;;
-    saveworld)
-      doSaveWorld
-    ;;
-    rconcmd)
-      rconcmd "$2"
-      shift
-    ;;
-    status)
-      printStatus
-    ;;
+  # handle upgrade-tools and uninstall-tools separately
+  case "$command" in
     upgrade-tools)
       doUpgradeTools
+      exit
     ;;
     uninstall-tools)
       doUninstallTools
-    ;;
-    useconfig)
-      useConfig "$2"
-      shift
+      exit
     ;;
     -h|--help)
-      echo -e "Usage: arkmanager [OPTION]\n"
-      echo "Option                Description"
-      echo "backup                Saves a backup of your server inside the backup directory"
-      echo "broadcast <msg>       Sends a message to all users connected to server"
-      echo "saveworld             Saves the game world to disk"
-      echo "rconcmd <cmd>         Execute RCON command on server"
-      echo "checkupdate           Check for a new ARK server version"
-      echo "install               Install the ARK server files from steamcmd"
-      echo "installmod <modid>    Installs a mod from the Steam workshop"
-      echo "restart               Stops the server and then starts it"
-      echo "restart --all         Restarts all servers specified in configfile_xxxxx"
-      echo "run                   Runs the server without daemonizing"
-      echo "start                 Starts the server"
-      echo "start --all           Starts all servers specified in configfile_xxxxx"
-      echo "stop                  Stops the server"
-      echo "stop --all            Stops all servers specified in configfile_xxxxx"
-      echo "status                Returns the status of the current ARK server instance"
-      echo "update [OPTION ...]   Check for a new ARK server version, if needed, stops the server, updates it, and starts it again"
-      echo "upgrade-tools         Check for a new ARK Server Tools version and upgrades it if needed"
-      echo "uninstall-tools       Uninstall the ARK Server Tools"
-      echo "useconfig <name>      Use the configuration overrides in the specified config name or file"
-      echo
-      echo "Update command takes the below options:"
-      echo "   --force            Apply update without checking the current version"
-      echo "   --safe             Wait for server to perform world save and update."
-      echo "   --warn             Warn players before updating server"
-      echo "   --validate         Validates all ARK server files"
-      echo "   --saveworld        Saves world before update"
-      echo "   --update-mods      Updates installed and requested mods"
-      echo "   --backup           Takes a backup of the save files before updating"
-      echo "   --downloadonly     Download the mod and/or server update without applying it"
-      echo "                      Requires arkStagingDir be set to a staging directory on the same filesystem as the server"
-      exit 1
-    ;;
-    *)
-      echo -n "arkmanager v${arkstVersion}: "
-      if [ $# -eq 0 ]; then
-        echo "no command specified"
-      else
-        echo "unknown command '$1' specified"
-      fi
-      echo "Try 'arkmanager -h' or 'arkmanager --help' for more information."
-      exit 1
+      showUsage
     ;;
   esac
-  shift
-  if [ $# -eq 0 ]; then
-    break
+
+  # get the number of arguments for commands that take arguments
+  case "$command" in
+    installmod) nrarg=1; ;;
+    broadcast) nrarg=1; ;;
+    rconcmd) nrarg=1; ;;
+  esac
+
+  # Enumerate the options, instances and arguments
+  while [ $# -ne 0 ]; do
+    case "$1" in
+      --*)
+        options+=( "$1" )
+      ;;
+      @all)
+        allinstances=yes
+      ;;
+      @*)
+        instances+=( "${1#@}" )
+      ;;
+      *)
+        if [ $nrarg -gt 0 ]; then
+          args+=( "$1" )
+        else
+          break
+        fi
+      ;;
+    esac
+    shift
+  done
+
+  # Handle no instances being specified
+  if [[ "${#instances[@]}" == 0 && "$allinstances" == "no" ]]; then
+    echo "No instances supplied for command ${command} ${options[*]} ${args[*]}"
+    read -p "Do you wish to run this command for all instances?" -n 1 -r
+    echo
+    if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+      allinstances=yes
+    else
+      exit 1
+    fi
+  fi
+
+  # Handle all instances being requested
+  if [[ "$allinstances" == "yes" ]]; then
+    instances=( )
+    for varname in "${!configfile_@}"; do
+      instances+=( "${varname#configfile_}" )
+    done
+  fi
+
+  # Run the command for each instance requested
+  for instance in "${instances[@]}"; do
+  (
+    echo "Running command '${command}' for instance '${instance}'"
+    useConfig "$instance"
+
+    case "$command" in
+      run)
+        doRun
+      ;;
+      start)
+        doStart
+      ;;
+      stop)
+        doStop
+      ;;
+      restart)
+        doStop
+        echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
+      ;;
+      install)
+        doInstall
+      ;;
+      update)
+        doUpdate "${options[@]}"
+      ;;
+      checkupdate)
+        checkForUpdate
+      ;;
+      installmod)
+        doInstallMod "${args[0]}"
+      ;;
+      backup)
+        doBackup
+      ;;
+      broadcast)
+        doBroadcast "${args[0]}"
+      ;;
+      saveworld)
+        doSaveWorld
+      ;;
+      rconcmd)
+        rconcmd "${args[0]}"
+      ;;
+      status)
+        printStatus
+      ;;
+      *)
+        echo -n "arkmanager v${arkstVersion}: "
+        if [ "$command" == "" ]; then
+          echo "no command specified"
+        else
+          echo "unknown command '$command' specified"
+        fi
+        echo "Try 'arkmanager -h' or 'arkmanager --help' for more information."
+        exit 1
+      ;;
+    esac
+  )
+  done
+
+  # Perform the restart portion of the restart command
+  if [[ "$command" == "restart" ]]; then
+    sleep 1
+    for instance in "${instances[@]}"; do
+    (
+      useConfig "$instance"
+      doStart
+      echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
+      echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"
+    )
+    done
   fi
 done

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1406,7 +1406,10 @@ useConfig() {
       return
     fi
   done
-  source "$1"
+  if [ -z "$arkserverroot" ]; then
+    echo "Error: arkserverroot not set"
+    exit 1
+  fi
 }
 
 showUsage() {

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -191,7 +191,7 @@ checkConfig() {
 
   # Environment configuration
   # arkserverexec
-  if [ ! -f "$arkserverroot/$arkserverexec" ] ; then
+  if [ -n "$arkserverroot" ] && [ ! -f "$arkserverroot/$arkserverexec" ] ; then
     echo -e "[" "$YELLOW" "WARN" "$NORMAL" "]" "\tYour ARK server exec could not be found."
   fi
 
@@ -1438,7 +1438,7 @@ useConfig() {
   for varname in "${!configfile_@}"; do
     if [ "configfile_$1" == "$varname" ]; then
       source "${!varname}"
-      return
+      break
     fi
   done
   if [ -z "$arkserverroot" ]; then
@@ -1576,6 +1576,7 @@ while [[ "$#" -gt 0 ]]; do
   (
     echo "Running command '${command}' for instance '${instance}'"
     useConfig "$instance"
+    checkConfig
 
     case "$command" in
       run)

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1400,9 +1400,6 @@ useConfig() {
   if [ -f "${HOME}/.config/arkmanager/instances/${1}.cfg" ]; then
     source "${HOME}/.config/arkmanager/instances/${1}.cfg"
   fi
-  if [ "$1" == "main" ]; then
-    return
-  fi
   for varname in "${!configfile_@}"; do
     if [ "configfile_$1" == "$varname" ]; then
       source "${!varname}"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1418,14 +1418,18 @@ getAllInstanceNames(){
 }
 
 doListAllInstances(){
-  echo "The following instances are available:"
-  for n in $(getAllInstanceNames); do
-    (
-      echo -n "  @${n}: "
-      useConfig "$n"
-      echo "${arkserverroot}"
-    )
-  done
+  if [ "$1" == "--brief" ]; then
+    getAllInstanceNames
+  else
+    echo "The following instances are available:"
+    for n in $(getAllInstanceNames); do
+      (
+        echo -n "  @${n}: "
+        useConfig "$n"
+        echo "${arkserverroot}"
+      )
+    done
+  fi
 }
 
 useConfig() {
@@ -1504,26 +1508,6 @@ while [[ "$#" -gt 0 ]]; do
   shift
   nrarg=0
 
-  # handle upgrade-tools and uninstall-tools separately
-  case "$command" in
-    upgrade-tools)
-      doUpgradeTools
-      exit
-    ;;
-    uninstall-tools)
-      doUninstallTools
-      exit
-    ;;
-    list-instances)
-      doListAllInstances
-      exit
-    ;;
-    -h|--help)
-      showUsage
-      exit
-    ;;
-  esac
-
   # get the number of arguments for commands that take arguments
   case "$command" in
     installmod) nrarg=1; ;;
@@ -1553,6 +1537,26 @@ while [[ "$#" -gt 0 ]]; do
     esac
     shift
   done
+
+  # handle instanceless commands separately
+  case "$command" in
+    upgrade-tools)
+      doUpgradeTools
+      exit
+    ;;
+    uninstall-tools)
+      doUninstallTools
+      exit
+    ;;
+    list-instances)
+      doListAllInstances "${options[@]}"
+      exit
+    ;;
+    -h|--help)
+      showUsage
+      exit
+    ;;
+  esac
 
   # Handle no instances being specified
   if [[ "${#instances[@]}" == 0 && "$allinstances" == "no" ]]; then

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -11,7 +11,6 @@ steamcmd_appinfocache="/home/steam/Steam/appcache/appinfo.vdf"      # cache of t
 #steamlogin="anonymous"                                             # Uncomment this to specify steam login instead of using anonymous login
 
 # config environment
-arkserverroot="/home/steam/ARK"                                     # path of your ARK server files (default ~/ARK)
 arkserverexec="ShooterGame/Binaries/Linux/ShooterGameServer"        # name of ARK server executable
 arkbackupdir="/home/steam/ARK-Backups"                              # path to backup directory
 arkwarnminutes="60"                                                 # number of minutes to warn players when using update --warn
@@ -25,17 +24,13 @@ arkTimeToKeepBackupFiles="10"                                       #Set to Auto
 msgWarnUpdateMinutes="This ARK server will shutdown for an update in %d minutes"
 msgWarnUpdateSeconds="This ARK server will shutdown for an update in %d seconds"
 
-# ARK server options - use ark_<optionname>=<value>
+# ARK server common options - use ark_<optionname>=<value>
 # comment out these values if you want to define them
 # inside your GameUserSettings.ini file
 serverMap="TheIsland"                                               # server map (default TheIsland)
 #serverMapModId="469987622"                                         # Uncomment this to specify the Map Mod Id (<fileid> in http://steamcommunity.com/sharedfiles/filedetails/?id=<fileid>)
 #ark_TotalConversionMod="496735411"                                 # Uncomment this to specify a total-conversion mod
 ark_RCONEnabled="True"                                              # Enable RCON Protocol
-ark_RCONPort="32330"                                                # RCON Port
-ark_SessionName="ARK Server Tools"                                  # if your session name needs special characters please use the .ini instead
-ark_Port="7778"                                                     # ARK server port (default 7778)
-ark_QueryPort="27016"                                               # ARK query port (default 27016)
 ark_ServerPassword=""                                               # ARK server password, empty: no password required to login
 ark_ServerAdminPassword="keyboardcat"                               # ARK server admin password, KEEP IT SAFE!
 ark_MaxPlayers="70"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -155,6 +155,9 @@ if [ "$userinstall" == "yes" ]; then
     # Create a folder in ~/logs to let Ark tools write its own log files
     mkdir -p "${INSTALL_ROOT}${PREFIX}/logs/arktools"
 
+    # Create a folder in ~/.config/arkamanger to hold instance configs
+    mkdir -p "${INSTALL_ROOT}${PREFIX}/.config/arkmanager/instances"
+
     # Copy arkmanager.cfg to ~/.arkmanager.cfg.NEW
     cp arkmanager.cfg "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
     # Change the defaults in the new config file
@@ -272,6 +275,10 @@ else
     # Create a folder in /var/log to let Ark tools write its own log files
     mkdir -p "${INSTALL_ROOT}/var/log/arktools"
     chown "$steamcmd_user" "${INSTALL_ROOT}/var/log/arktools"
+
+    # Create a folder in /etc/arkmanager to hold instance config files
+    mkdir -p "${INSTALL_ROOT}/etc/arkmanager/instances"
+    chown "$steamcmd_user" "${INSTALL_ROOT}/etc/arkmanager/instances"
 
     # Copy arkmanager.cfg inside linux configuation folder if it doesn't already exists
     mkdir -p "${INSTALL_ROOT}/etc/arkmanager"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -210,6 +210,7 @@ else
       if [ -f /etc/systemd/system.conf ]; then   # used by systemd
         mkdir -p "${INSTALL_ROOT}${LIBEXECDIR}"
         cp systemd/arkmanager.init "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+        sed -i "s|^DAEMON=\"/usr/bin/|DAEMON=\"${BINDIR}/|" "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         chmod +x "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         cp systemd/arkmanager.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
@@ -237,6 +238,7 @@ else
       if [ -f /etc/systemd/system.conf ]; then   # used by systemd
         mkdir -p "${INSTALL_ROOT}${LIBEXECDIR}"
         cp systemd/arkmanager.init "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+        sed -i "s|^DAEMON=\"/usr/bin/|DAEMON=\"${BINDIR}/|" "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         chmod +x "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
         cp systemd/arkmanager.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
@@ -270,6 +272,7 @@ else
     elif [ -f /etc/systemd/system.conf ]; then   # used by systemd
       mkdir -p "${INSTALL_ROOT}${LIBEXECDIR}"
       cp systemd/arkmanager.init "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
+      sed -i "s|^DAEMON=\"/usr/bin/|DAEMON=\"${BINDIR}/|" "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
       chmod +x "${INSTALL_ROOT}${LIBEXECDIR}/arkmanager.init"
       cp systemd/arkmanager.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
       sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -99,10 +99,14 @@ if [ "$userinstall" == "yes" ]; then
   PREFIX="${PREFIX:-${HOME}}"
   EXECPREFIX="${EXECPREFIX:-${PREFIX}}"
   DATAPREFIX="${DATAPREFIX:-${PREFIX}/.local/share}"
+  CONFIGFILE="${PREFIX}/.arkmanager.cfg"
+  INSTANCEDIR="${PREFIX}/.config/arkmanager/instances"
 else
   PREFIX="${PREFIX:-/usr/local}"
   EXECPREFIX="${EXECPREFIX:-${PREFIX}}"
   DATAPREFIX="${DATAPREFIX:-${PREFIX}/share}"
+  CONFIGFILE="/etc/arkmanager/.arkmanager.cfg"
+  INSTANCEDIR="/etc/arkmanager/instances"
 fi
 
 BINDIR="${BINDIR:-${EXECPREFIX}/bin}"
@@ -156,13 +160,16 @@ if [ "$userinstall" == "yes" ]; then
     mkdir -p "${INSTALL_ROOT}${PREFIX}/logs/arktools"
 
     # Create a folder in ~/.config/arkamanger to hold instance configs
-    mkdir -p "${INSTALL_ROOT}${PREFIX}/.config/arkmanager/instances"
+    mkdir -p "${INSTALL_ROOT}${INSTANCEDIR}"
 
     # Copy example instance config
-    cp instance.cfg.example "${INSTALL_ROOT}/${PREFIX}/.config/arkamanger/instances/instance.cfg.example"
+    cp instance.cfg.example "${INSTALL_ROOT}/${INSTANCEDIR}/instance.cfg.example"
+    # Change the defaults in the new instance config template
+    sed -i -e "s|\"/home/steam|\"${PREFIX}|" \
+           "${INSTALL_ROOT}${INSTANCEDIR}/instance.cfg.example"
 
     # Copy arkmanager.cfg to ~/.arkmanager.cfg.NEW
-    cp arkmanager.cfg "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
+    cp arkmanager.cfg "${INSTALL_ROOT}${CONFIGFILE}.NEW"
     # Change the defaults in the new config file
     sed -i -e "s|^steamcmd_user=\"steam\"|steamcmd_user=\"--me\"|" \
            -e "s|\"/home/steam|\"${PREFIX}|" \
@@ -170,17 +177,17 @@ if [ "$userinstall" == "yes" ]; then
            -e "s|^install_bindir=.*|install_bindir=\"${BINDIR}\"|" \
            -e "s|^install_libexecdir=.*|install_libexecdir=\"${LIBEXECDIR}\"|" \
            -e "s|^install_datadir=.*|install_datadir=\"${DATADIR}\"|" \
-           "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
+           "${INSTALL_ROOT}${CONFIGFILE}.NEW"
 
     # Copy arkmanager.cfg to ~/.arkmanager.cfg if it doesn't already exist
-    if [ -f "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg" ]; then
-      bash ./migrate-config.sh "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
+    if [ -f "${INSTALL_ROOT}${CONFIGFILE}" ]; then
+      bash ./migrate-config.sh "${INSTALL_ROOT}${CONFIGFILE}"
 
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
-      echo "A copy of the new configuration file was included in '${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW'. Make sure to review any changes and update your config accordingly!"
+      echo "A copy of the new configuration file was included in '${CONFIGFILE}.NEW'. Make sure to review any changes and update your config accordingly!"
       exit 2
     else
-      mv -n "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW" "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
+      mv -n "${INSTALL_ROOT}${CONFIGFILE}.NEW" "${INSTALL_ROOT}${CONFIGFILE}"
     fi
 else
     # Copy arkmanager to /usr/bin and set permissions
@@ -280,31 +287,31 @@ else
     chown "$steamcmd_user" "${INSTALL_ROOT}/var/log/arktools"
 
     # Create a folder in /etc/arkmanager to hold instance config files
-    mkdir -p "${INSTALL_ROOT}/etc/arkmanager/instances"
-    chown "$steamcmd_user" "${INSTALL_ROOT}/etc/arkmanager/instances"
+    mkdir -p "${INSTALL_ROOT}${INSTANCEDIR}"
+    chown "$steamcmd_user" "${INSTALL_ROOT}${INSTANCEDIR}"
 
     # Copy example instance config
-    cp instance.cfg.example "${INSTALL_ROOT}/etc/arkamanger/instances/instance.cfg.example"
+    cp instance.cfg.example "${INSTALL_ROOT}${INSTANCEDIR}/instance.cfg.example"
 
     # Copy arkmanager.cfg inside linux configuation folder if it doesn't already exists
     mkdir -p "${INSTALL_ROOT}/etc/arkmanager"
-    cp arkmanager.cfg "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
-    chown "$steamcmd_user" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
+    cp arkmanager.cfg "${INSTALL_ROOT}${CONFIGFILE}.NEW"
+    chown "$steamcmd_user" "${INSTALL_ROOT}${CONFIGFILE}.NEW"
     sed -i -e "s|^steamcmd_user=\"steam\"|steamcmd_user=\"$steamcmd_user\"|" \
            -e "s|\"/home/steam|\"/home/$steamcmd_user|" \
            -e "s|^install_bindir=.*|install_bindir=\"${BINDIR}\"|" \
            -e "s|^install_libexecdir=.*|install_libexecdir=\"${LIBEXECDIR}\"|" \
            -e "s|^install_datadir=.*|install_datadir=\"${DATADIR}\"|" \
-           "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
+           "${INSTALL_ROOT}${CONFIGFILE}.NEW"
 
-    if [ -f "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg" ]; then
-      bash ./migrate-config.sh "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
+    if [ -f "${INSTALL_ROOT}${CONFIGFILE}" ]; then
+      bash ./migrate-config.sh "${INSTALL_ROOT}${CONFIGFILE}"
 
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
       echo "A copy of the new configuration file was included in /etc/arkmanager. Make sure to review any changes and update your config accordingly!"
       exit 2
     else
-      mv -n "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
+      mv -n "${INSTALL_ROOT}${CONFIGFILE}.NEW" "${INSTALL_ROOT}${CONFIGFILE}.cfg"
     fi
 fi
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -182,6 +182,7 @@ if [ "$userinstall" == "yes" ]; then
     # Copy arkmanager.cfg to ~/.arkmanager.cfg if it doesn't already exist
     if [ -f "${INSTALL_ROOT}${CONFIGFILE}" ]; then
       bash ./migrate-config.sh "${INSTALL_ROOT}${CONFIGFILE}"
+      bash ./migrate-main-instance.sh "${INSTALL_ROOT}${CONFIGFILE}" "${INSTALL_ROOT}${INSTANCEDIR}/main.cfg"
 
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
       echo "A copy of the new configuration file was included in '${CONFIGFILE}.NEW'. Make sure to review any changes and update your config accordingly!"
@@ -306,6 +307,7 @@ else
 
     if [ -f "${INSTALL_ROOT}${CONFIGFILE}" ]; then
       bash ./migrate-config.sh "${INSTALL_ROOT}${CONFIGFILE}"
+      bash ./migrate-main-instance.sh "${INSTALL_ROOT}${CONFIGFILE}" "${INSTALL_ROOT}${INSTANCEDIR}/main.cfg"
 
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
       echo "A copy of the new configuration file was included in /etc/arkmanager. Make sure to review any changes and update your config accordingly!"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -158,6 +158,9 @@ if [ "$userinstall" == "yes" ]; then
     # Create a folder in ~/.config/arkamanger to hold instance configs
     mkdir -p "${INSTALL_ROOT}${PREFIX}/.config/arkmanager/instances"
 
+    # Copy example instance config
+    cp instance.cfg.example "${INSTALL_ROOT}/${PREFIX}/.config/arkamanger/instances/instance.cfg.example"
+
     # Copy arkmanager.cfg to ~/.arkmanager.cfg.NEW
     cp arkmanager.cfg "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW"
     # Change the defaults in the new config file
@@ -279,6 +282,9 @@ else
     # Create a folder in /etc/arkmanager to hold instance config files
     mkdir -p "${INSTALL_ROOT}/etc/arkmanager/instances"
     chown "$steamcmd_user" "${INSTALL_ROOT}/etc/arkmanager/instances"
+
+    # Copy example instance config
+    cp instance.cfg.example "${INSTALL_ROOT}/etc/arkamanger/instances/instance.cfg.example"
 
     # Copy arkmanager.cfg inside linux configuation folder if it doesn't already exists
     mkdir -p "${INSTALL_ROOT}/etc/arkmanager"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -296,6 +296,7 @@ else
 
     # Copy arkmanager.cfg inside linux configuation folder if it doesn't already exists
     mkdir -p "${INSTALL_ROOT}/etc/arkmanager"
+    chown "$steamcmd_user" "${INSTALL_ROOT}/etc/arkmanager"
     cp arkmanager.cfg "${INSTALL_ROOT}${CONFIGFILE}.NEW"
     chown "$steamcmd_user" "${INSTALL_ROOT}${CONFIGFILE}.NEW"
     sed -i -e "s|^steamcmd_user=\"steam\"|steamcmd_user=\"$steamcmd_user\"|" \

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -168,25 +168,7 @@ if [ "$userinstall" == "yes" ]; then
 
     # Copy arkmanager.cfg to ~/.arkmanager.cfg if it doesn't already exist
     if [ -f "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg" ]; then
-      newopts=( arkbackupdir arkautorestartfile install_bindir install_libexecdir install_datadir mod_appid )
-      newopt_steamcmd_appinfocache="${PREFIX}/Steam/appcache/appinfo.vdf"
-      newopt_arkbackupdir="${PREFIX}/ARK-Backups"
-      newopt_arkautorestartfile="ShooterGame/Saved/.autorestart"
-      newopt_install_bindir="${BINDIR}"
-      newopt_install_libexecdir="${LIBEXECDIR}"
-      newopt_install_datadir="${DATADIR}"
-      newopt_mod_appid=346110
-
-      if grep '^\(servermail\|arkstVersion\)=' "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg" >/dev/null 2>&1; then
-        sed -i '/^\(servermail\|arkstVersion\)=/d' "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
-      fi
-
-      for optname in "${newopts[@]}"; do
-        if ! grep "^${optname}=" "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg" >/dev/null 2>&1; then
-	  noptname="newopt_${optname}"
-	  echo "${optname}='${!noptname}'" >>"${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
-	fi
-      done
+      bash ./migrate-config.sh "${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg"
 
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
       echo "A copy of the new configuration file was included in '${INSTALL_ROOT}${PREFIX}/.arkmanager.cfg.NEW'. Make sure to review any changes and update your config accordingly!"
@@ -303,25 +285,7 @@ else
            "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg.NEW"
 
     if [ -f "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg" ]; then
-      newopts=( arkbackupdir arkautorestartfile install_bindir install_libexecdir install_datadir mod_appid )
-      newopt_steamcmd_appinfocache="/home/${steamcmd_user}/Steam/appcache/appinfo.vdf"
-      newopt_arkbackupdir="/home/${steamcmd_user}/ARK-Backups"
-      newopt_arkautorestartfile="ShooterGame/Saved/.autorestart"
-      newopt_install_bindir="${BINDIR}"
-      newopt_install_libexecdir="${LIBEXECDIR}"
-      newopt_install_datadir="${DATADIR}"
-      newopt_mod_appid=346110
-
-      if grep '^\(servermail\|arkstVersion\)=' "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg" >/dev/null 2>&1; then
-        sed -i '/^\(servermail\|arkstVersion\)=/d' "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
-      fi
-
-      for optname in "${newopts[@]}"; do
-        if ! grep "^${optname}=" "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg" >/dev/null 2>&1; then
-	  noptname="newopt_${optname}"
-	  echo "${optname}='${!noptname}'" >>"${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
-	fi
-      done
+      bash ./migrate-config.sh "${INSTALL_ROOT}/etc/arkmanager/arkmanager.cfg"
 
       echo "A previous version of ARK Server Tools was detected in your system, your old configuration was not overwritten. You may need to manually update it."
       echo "A copy of the new configuration file was included in /etc/arkmanager. Make sure to review any changes and update your config accordingly!"

--- a/tools/instance.cfg.example
+++ b/tools/instance.cfg.example
@@ -1,0 +1,28 @@
+# config environment
+arkserverroot="/home/steam/ARK"                                     # path of your ARK server files (default ~/ARK)
+
+# ARK server options - use ark_<optionname>=<value>
+# comment out these values if you want to define them
+# inside your GameUserSettings.ini file
+serverMap="TheIsland"                                               # server map (default TheIsland)
+#serverMapModId="469987622"                                         # Uncomment this to specify the Map Mod Id (<fileid> in http://steamcommunity.com/sharedfiles/filedetails/?id=<fileid>)
+#ark_TotalConversionMod="496735411"                                 # Uncomment this to specify a total-conversion mod
+ark_RCONEnabled="True"                                              # Enable RCON Protocol
+ark_RCONPort="32330"                                                # RCON Port
+ark_SessionName="ARK Server Tools"                                  # if your session name needs special characters please use the .ini instead
+ark_Port="7778"                                                     # ARK server port (default 7778)
+ark_QueryPort="27016"                                               # ARK query port (default 27016)
+ark_ServerPassword=""                                               # ARK server password, empty: no password required to login
+ark_ServerAdminPassword="keyboardcat"                               # ARK server admin password, KEEP IT SAFE!
+ark_MaxPlayers="70"
+#ark_GameModIds="487516323,487516324,487516325"                     # Uncomment to specify additional mods by Mod Id separated by commas
+#ark_AltSaveDirectoryName="SotF"                                    # Uncomment to specify a different save directory name
+
+# ARK server flags - use arkflag_<optionname>=true
+#arkflag_OnlyAdminRejoinAsSpectator=true                            # Uncomment to only allow admins to rejoin as spectator
+#arkflag_DisableDeathSpectator=true                                 # Uncomment to disable players from becoming spectators when they die
+
+# ARK server options - i.e. for -optname=val, use arkopt_optname=val
+#arkopt_StructureDestructionTag=DestroySwampSnowStructures
+
+

--- a/tools/lsb/arkdaemon
+++ b/tools/lsb/arkdaemon
@@ -20,46 +20,99 @@ NAME="ShooterGameServer"
 LOGFILE="${logdir}/${NAME}.log"
 DAEMON="/usr/bin/arkmanager"
 
+SVCNAME="${0##*/}"
+INSTANCE="${SVCNAME#*.}"
+
+if [ "$INSTANCE" == "$SVCNAME" ]; then
+  INSTANCE="$2"
+fi
+
 set -e
 
 # If the daemon is not there, then exit.
 test -x $DAEMON || exit 5
 
+function start_instance(){
+  local INSTANCE="$1"
+  PID="$(<"/var/run/arkmanager.${INSTANCE}.pid")"
+  if [ -n "$PID" ] && kill -0 "$PID" >/dev/null 2>&1; then
+    if grep " ${PID} .* ${DAEMON}" <(ps -ef) >/dev/null 2>&1; then
+      echo "$NAME @${INSTANCE} is already running"
+      return 0
+    fi
+  fi
+  log_daemon_msg "Starting" "$NAME @${INSTANCE}"
+  ulimit -n 100000
+  "${DAEMON}" run "@${INSTANCE}" &
+  PID="$!"
+
+  sleep 5
+  if kill -0 "$PID" >/dev/null 2>&1; then
+    echo "$PID" >"/var/run/arkmanager.${INSTANCE}.pid"
+    log_end_msg 0
+    return 0
+  else
+    log_end_msg 1
+    return 1
+  fi
+}
+
+function start_all_instances(){
+  local nosuccess=0
+  local anyfailure=0
+  for instance in $("${DAEMON}" list-instances --brief); do
+    if start_instance "$instance"; then
+      nosuccess=0
+    else
+      anyfailure=1
+    fi
+  done
+
+  return $nosuccess
+}
+
+function stop_instance(){
+  local INSTANCE="$1"
+  log_daemon_msg "Stopping $NAME @${INSTANCE}: "
+  "${DAEMON}" stop "@${INSTANCE}" &
+  rm -f "/var/run/arkmanager.${INSTANCE}.pid"
+  log_end_msg 0
+  return 0
+}
+
 case "$1" in
   start)
-    log_daemon_msg "Starting" "$NAME"
-    ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON start --all" $steamcmd_user
-    sleep 5
-    PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
-    if  [ -n "$PID" ];  then
-      echo "$PID" >/var/run/arkmanager.pid
-      log_end_msg 0
+    if [ -n "$INSTANCE" ]; then
+      start_instance "$INSTANCE"
+      exit $?
     else
-      log_end_msg 1
+      if start_all_instances; then
+        exit 0
+      else
+        exit 1
+      fi
     fi
   ;;
 
   stop)
-    log_daemon_msg "Stopping" "$NAME"
-    su -s /bin/sh -c "$DAEMON stop --all" $steamcmd_user
-    sleep 5
-    PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
-    if  [ -n "$PID" ];  then
-      log_end_msg 1
+    if [ -n "$INSTANCE" ]; then
+      stop_instance "$INSTANCE"
+      exit $?
     else
-      rm /var/run/arkmanager.pid
-      log_end_msg 0
+      for instance in $("${DAEMON}" list-instances --brief); do
+        stop_instance "$instance"
+      done
+      exit $?
     fi
   ;;
 
   restart)
-    ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON restart --all" $steamcmd_user
+    "$0" stop
+    "$0" start
   ;;
 
   status)
-    su -s /bin/sh -c "$DAEMON status" $steamcmd_user
+    "$DAEMON" status "@${INSTANCE:-all}"
   ;;
 
   *)

--- a/tools/migrate-config.sh
+++ b/tools/migrate-config.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+configfile="$1"
+newopts=( arkbackupdir arkautorestartfile install_bindir install_libexecdir install_datadir mod_appid )
+newopt_steamcmd_appinfocache="${PREFIX}/Steam/appcache/appinfo.vdf"
+newopt_arkbackupdir="${PREFIX}/ARK-Backups"
+newopt_arkautorestartfile="ShooterGame/Saved/.autorestart"
+newopt_install_bindir="${BINDIR}"
+newopt_install_libexecdir="${LIBEXECDIR}"
+newopt_install_datadir="${DATADIR}"
+newopt_mod_appid=346110
+
+if grep '^\(servermail\|arkstVersion\)=' "${configfile}" >/dev/null 2>&1; then
+  sed -i '/^\(servermail\|arkstVersion\)=/d' "${configfile}"
+fi
+
+for optname in "${newopts[@]}"; do
+  if ! grep "^${optname}=" "${configfile}" >/dev/null 2>&1; then
+    noptname="newopt_${optname}"
+    echo "${optname}='${!noptname}'" >>"${configfile}"
+  fi
+done
+

--- a/tools/migrate-main-instance.sh
+++ b/tools/migrate-main-instance.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+configfile="$1"
+instancefile="$2"
+
+if grep "^arkserverroot=" <"$configfile" >/dev/null 2>&1 && [ ! -f "$instancefile" ]; then
+  sed -n '/^#*\(ark\(\|flag\|opt\)_[^=]*\|arkserverroot\|serverMap\(\|ModId\)\)=/p' <"$configfile" >"$instancefile"
+  sed -i '/^ark\(serverroot\|_\(RCONPort\|Port\|QueryPort\)\)=/d' "$configfile"
+fi

--- a/tools/openrc/arkdaemon
+++ b/tools/openrc/arkdaemon
@@ -13,27 +13,25 @@ depend(){
 }
 
 start(){
+    INSTANCE="${RC_SVCNAME#*.}"
     ebegin "Starting ARK manager daemon"
     ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON start --all" $steamcmd_user
-    sleep 5
-    PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
-    if  [ -n "$PID" ];  then
-        eend 0
+    if [ "$INSTANCE" != "$RC_SVCNAME" ]; then
+        "$DAEMON" start "@${INSTANCE}"
     else
-        eend 1
+        "$DAEMON" start "@all"
     fi
+    eend $?
 }
 
 stop(){
+    INSTANCE="${RC_SVCNAME#*.}"
     ebegin "Stopping ARK manager daemon"
-    su -s /bin/sh -c "$DAEMON stop --all" $steamcmd_user
-    sleep 5
-    PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
-    if  [ -n "$PID" ];  then
-        eend 0
+    if [ "$INSTANCE" != "$RC_SVCNAME" ]; then
+        "$DAEMON" stop "@${INSTANCE}"
     else
-        eend 1
+        "$DAEMON" stop "@all"
     fi
+    eend $?
 }
 

--- a/tools/redhat/arkdaemon
+++ b/tools/redhat/arkdaemon
@@ -34,54 +34,103 @@ GREEN="\\033[1;32m"
 RED="\\033[1;31m"
 NORMAL="\\033[0;39m"
 
+SVCNAME="${0##*/}"
+INSTANCE="${SVCNAME#*.}"
+
+if [ "$INSTANCE" == "$SVCNAME" ]; then
+  INSTANCE="$2"
+fi
+
 set -e
 
 # If the daemon is not there, then exit.
 test -x $DAEMON || exit 5
 
+function start_instance(){
+  local INSTANCE="$1"
+  PID="$(<"/var/run/arkmanager.${INSTANCE}.pid")"
+  if [ -n "$PID" ] && kill -0 "$PID" >/dev/null 2>&1; then
+    if grep " ${PID} .* ${DAEMON}" <(ps -ef) >/dev/null 2>&1; then
+      echo "$NAME @${INSTANCE} is already running"
+      return 0
+    fi
+  fi
+  echo -n "Starting $NAME @${INSTANCE}: "
+  ulimit -n 100000
+  "${DAEMON}" run "@${INSTANCE}" &
+  PID="$!"
+
+  sleep 5
+  if kill -0 "$PID" >/dev/null 2>&1; then
+    echo "$PID" >"/var/run/arkmanager.${INSTANCE}.pid"
+    touch "/var/lock/subsys/arkmanager.${INSTANCE}"
+    echo "[" "$GREEN" " OK " "$NORMAL" "]"
+    return 0
+  else
+    echo "[" "$RED" " FAILED " "$NORMAL" "]"
+    return 1
+  fi
+}
+
+function start_all_instances(){
+  local nosuccess=0
+  local anyfailure=0
+  for instance in $("${DAEMON}" list-instances --brief); do
+    if start_instance "$instance"; then
+      nosuccess=0
+    else
+      anyfailure=1
+    fi
+  done
+
+  return $nosuccess
+}
+
+function stop_instance(){
+  local INSTANCE="$1"
+  echo -n "Stopping $NAME @${INSTANCE}: "
+  "${DAEMON}" stop "@${INSTANCE}" &
+  rm -f "/var/lock/subsys/arkmanager.${INSTANCE}"
+  rm -f "/var/run/arkmanager.${INSTANCE}.pid"
+  echo "[" "$GREEN" " OK " "$NORMAL" "]"
+  return 0
+}
+
 case "$1" in
   start)
-    echo -n "Starting $NAME: "
-    ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON start --all" $steamcmd_user > /dev/null
-    sleep 5
-    PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
-    if  [ -n "$PID" ];  then
-      echo "${PID}" >/var/run/arkmanager.pid
-      touch /var/lock/subsys/arkmanager
-      echo "[" "$GREEN" " OK " "$NORMAL" "]"
-      exit 0
+    if [ -n "$INSTANCE" ]; then
+      start_instance "$INSTANCE"
+      exit $?
     else
-      echo "[" "$RED" " FAILED " "$NORMAL" "]"
-      exit 1
+      if start_all_instances; then
+        touch /var/lock/subsys/arkmanager
+        exit 0
+      else
+        exit 1
+      fi
     fi
   ;;
 
   stop)
-    echo -n "Stopping $NAME: "
-    su -s /bin/sh -c "$DAEMON stop --all" $steamcmd_user > /dev/null
-    sleep 5
-    PID=`ps -ef | grep $NAME | grep -v grep | awk '{print $2}'`
-    if  [ -n "$PID" ];  then
-      echo "[" "$RED" " FAILED " "$NORMAL" "]"
-      exit 1
+    if [ -n "$INSTANCE" ]; then
+      stop_instance "$INSTANCE"
+      exit $?
     else
-      echo "[" "$GREEN" " OK " "$NORMAL" "]"
-      rm -f /var/lock/subsys/arkmanager
-      rm -f /var/run/arkmanager.pid
-      exit 0
+      for instance in $("${DAEMON}" list-instances --brief); do
+        stop_instance "$instance"
+      done
+      rm -f "/var/lock/subsys/arkmanager"
+      exit $?
     fi
   ;;
 
   restart)
-    echo -n "Restarting $NAME: "
-    ulimit -n 100000
-    su -s /bin/sh -c "$DAEMON restart --all" $steamcmd_user > /dev/null
-    echo "OK"
+    "$0" stop
+    "$0" start
   ;;
 
   status)
-    su -s /bin/sh -c "$DAEMON status" $steamcmd_user
+    "$DAEMON" status "@${INSTANCE:-all}"
     exit 0
   ;;
 

--- a/tools/systemd/arkmanager.init
+++ b/tools/systemd/arkmanager.init
@@ -1,5 +1,14 @@
 #!/bin/bash
 
-for service in main $(grep -o '^configfile_[^=]*' /etc/arkmanager/arkmanager.cfg); do
-  systemctl start arkmanager@${service#configfile_}
+DAEMON=/usr/bin/arkmanager
+
+for service in $(${DAEMON} list-instances --brief); do
+  case "$1" in
+    start)
+      systemctl start arkmanager@${service}
+    ;;
+    stop)
+      systemctl stop arkmanager@${service}
+    ;;
+  esac
 done

--- a/tools/upstart/arkmanager.conf
+++ b/tools/upstart/arkmanager.conf
@@ -1,8 +1,10 @@
 start on runlevel [345]
 stop on runlevel [!345]
 
+env DAEMON="/usr/bin/arkmanager"
+
 script
-  for service in main $(grep -o '^configfile_[^=]*' /etc/arkmanager/arkmanager.cfg); do
-    start arkmanager-instance service=${service#configfile_}
+  for service in $(${DAEMON} list-instances --brief); do
+    start arkmanager-instance service=${service}
   done
 end script


### PR DESCRIPTION
This adds support for each command to be run on a set of instances.

This was requested in #290.

This instance support replaces the `useconfig` command.

If the core config contains instance-specific settings, and the `main` instance config file doesn't exist, then the instance settings are migrated out of the core config and into the `main` instance config file.

e.g.
```
$ arkmanager status @main @test checkupdate @main stop @all
Running command 'status' for instance 'main'
 Server running:   No 
 Server listening:   No 
 Server version:   861140 
Running command 'status' for instance 'test'
[  WARN  ]      Your ARK server exec could not be found.
 Server running:   No 
 Server listening:   No 
 Server version:   
Running command 'checkupdate' for instance 'main'
Querying Steam database for latest version...
Current version:  861140 
Available version:  868157 
Your server needs to be restarted in order to receive the latest update.
Run "arkmanager update" to do so
Running command 'stop' for instance 'main'
The server is already stopped
Running command 'stop' for instance 'test'
[  WARN  ]      Your ARK server exec could not be found.
The server is already stopped
```