### PR TITLE
Implement old backup removal

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1349,6 +1349,10 @@ doBackup(){
     echo -e "${NORMAL}\e[68G[ ${RED}FAILED${NORMAL} ]"
   fi
   echo -e "${NORMAL} Created Backup: ${GREEN} ${datestamp}.tar.bz2${NORMAL}"
+
+  if [ -n "$arkTimeToKeepBackupFiles" ]; then
+    find "${arkbackupdir}" -type f -mtime +$arkTimeToKeepBackupFiles -exec rm "{}" \;
+  fi
 }
 
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1340,18 +1340,18 @@ doBackup(){
 
   echo -ne "${NORMAL} Compressing Backup "
 
-  tar -jcf "${arkbackupdir}/${daystamp}/${datestamp}.tar.bz2" -C "${arkbackupdir}" "${datestamp}"
+  tar -jcf "${arkbackupdir}/${arkBackupPrefix}${daystamp}/${arkBackupPrefix}${datestamp}.tar.bz2" -C "${arkbackupdir}" "${datestamp}"
   rm -rf ${backupdir}
 
-  if [ -f "${arkbackupdir}/${daystamp}/${datestamp}.tar.bz2" ]; then
+  if [ -f "${arkbackupdir}/${arkBackupPrefix}${daystamp}/${arkBackupPrefix}${datestamp}.tar.bz2" ]; then
    echo -e "${NORMAL}\e[68G[   ${GREEN}OK${NORMAL}   ]"
   else
     echo -e "${NORMAL}\e[68G[ ${RED}FAILED${NORMAL} ]"
   fi
-  echo -e "${NORMAL} Created Backup: ${GREEN} ${datestamp}.tar.bz2${NORMAL}"
+  echo -e "${NORMAL} Created Backup: ${GREEN} ${arkBackupPrefix}${datestamp}.tar.bz2${NORMAL}"
 
   if [ -n "$arkTimeToKeepBackupFiles" ]; then
-    find "${arkbackupdir}" -type f -mtime +$arkTimeToKeepBackupFiles -exec rm "{}" \;
+    find "${arkbackupdir}" -name "${arkBackupPrefix}*" -type f -mtime +$arkTimeToKeepBackupFiles -exec rm "{}" \;
   fi
 }
 

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -18,6 +18,7 @@ arkwarnminutes="60"                                                 # number of 
 arkautorestartfile="ShooterGame/Saved/.autorestart"                 # path to autorestart file
 arkBackupPreUpdate="false"                                          # set this to true if you want to perform a backup before updating
 arkTimeToKeepBackupFiles="10"                                       #Set to Automatically Remove backups older than n days
+#arkBackupPrefix="main-"                                            # Uncomment to set a prefix for the ARK backup files
 #arkStagingDir="/home/steam/ARK-Staging"                            # Uncomment to enable updates to be fully downloaded before restarting the server (reduces downtime while updating)
 
 # Update warning messages


### PR DESCRIPTION
This was requested in #300.  The `arkTimeToKeepBackupFiles` setting was added in #275, but the logic to use it was not implemented.

Also add `arkBackupPrefix` to separate backups from multiple instances.