### PR TITLE
 Implement old backup removal by limiting backup size

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1427,6 +1427,22 @@ doBackup(){
     echo -e "${NORMAL}\e[68G[ ${RED}FAILED${NORMAL} ]"
   fi
   echo -e "${NORMAL} Created Backup: ${GREEN} ${datestamp}.tar.bz2${NORMAL}"
+
+  if [ -n "$arkMaxBackupSizeGB" ] && (( arkMaxBackupSizeGB >= 1 )); then
+    (( arkMaxBackupSizeMB = arkMaxBackupSizeGB * 1024 ))
+  fi
+
+  if [ -n "$arkMaxBackupSizeMB" ] && (( arkMaxBackupSizeMB > 64 )); then
+    find "${arkbackupdir}" -type f -printf "%T@\t%s\t%p\n" |
+      sort -n -r |
+      cut -f2-3 |
+      (sz=0; while read fsz f; do
+	if (( sz / 1048576 > arkMaxBackupSizeMB )); then
+	  rm "$f"
+	fi
+        (( sz += fsz ))
+      done)
+  fi
 }
 
 

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -17,9 +17,12 @@ arkbackupdir="/home/steam/ARK-Backups"                              # path to ba
 arkwarnminutes="60"                                                 # number of minutes to warn players when using update --warn
 arkautorestartfile="ShooterGame/Saved/.autorestart"                 # path to autorestart file
 arkBackupPreUpdate="false"                                          # set this to true if you want to perform a backup before updating
+#arkStagingDir="/home/steam/ARK-Staging"                            # Uncomment to enable updates to be fully downloaded before restarting the server (reduces downtime while updating)
+
+# Options to automatically remove old backups to keep backup size in check
+# Each compressed backup is generally about 1-2MB in size.
 arkMaxBackupSizeMB="500"                                            # Set to automatically remove old backups when size exceeds this limit
 #arkMaxBackupSizeGB="2"                                             # Uncomment this and comment the above to specify the limit in whole GB
-#arkStagingDir="/home/steam/ARK-Staging"                            # Uncomment to enable updates to be fully downloaded before restarting the server (reduces downtime while updating)
 
 # Update warning messages
 # Modify as desired, putting the %d replacement operator where the number belongs

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -17,7 +17,8 @@ arkbackupdir="/home/steam/ARK-Backups"                              # path to ba
 arkwarnminutes="60"                                                 # number of minutes to warn players when using update --warn
 arkautorestartfile="ShooterGame/Saved/.autorestart"                 # path to autorestart file
 arkBackupPreUpdate="false"                                          # set this to true if you want to perform a backup before updating
-arkTimeToKeepBackupFiles="10"                                       #Set to Automatically Remove backups older than n days
+arkMaxBackupSizeMB="500"                                            # Set to automatically remove old backups when size exceeds this limit
+#arkMaxBackupSizeGB="2"                                             # Uncomment this and comment the above to specify the limit in whole GB
 #arkStagingDir="/home/steam/ARK-Staging"                            # Uncomment to enable updates to be fully downloaded before restarting the server (reduces downtime while updating)
 
 # Update warning messages


### PR DESCRIPTION
This allows the game server administrator to specify the maximum backup size in MB. The oldest backups will be removed until the backup directory size is below this size.

A similar capability (removing backups beyond a certain age) was requested in #300.