### PR TITLE
Return the status from the last command run

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -334,11 +334,13 @@ function checkForUpdate(){
     echo -e "Available version:" "$GREEN" $bnumber "$NORMAL"
     echo -e "Your server needs to be restarted in order to receive the latest update."
     echo -e "Run \"arkmanager update\" to do so"
+    return 1
   else
     tput rc; tput ed;
     echo -e "Current version:" "$GREEN" $instver "$NORMAL"
     echo -e "Available version:" "$GREEN" $bnumber "$NORMAL"
     echo "Your server is up to date!"
+    return 0
   fi
 }
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1410,8 +1410,11 @@ while true; do
       exit 1
     ;;
   esac
+  status=$?
   shift
   if [ $# -eq 0 ]; then
     break
   fi
 done
+
+exit $status


### PR DESCRIPTION
Returns the status from the last command run.
Also returns a non-zero status from checkupdate when an update is required.
This was requested (in a round-about way) in #306.