### PR TITLE
Ignore SIGPIPE in ARK server

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -569,9 +569,11 @@ doRun() {
     printf " %q" "$arkserverroot/$arkserverexec" "$arkserveropts" "${arkextraopts[@]}"
     echo
     # Put the server process into the background so we can monitor it
+    trap "" PIPE
     "$arkserverroot/$arkserverexec" "$arkserveropts" "${arkextraopts[@]}" &
     # Grab the server PID
     serverpid=$!
+    trap - PIPE
     echo "`timestamp`: Server PID: $serverpid"
     # Disable auto-restart so we don't get caught in a restart loop
     rm -f "$arkserverroot/$arkautorestartfile"


### PR DESCRIPTION
This should resolve the server crash (if there is one caused by `SIGPIPE`) in #304.