### PR TITLE
Fix retrieving settings from ini file

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -212,7 +212,7 @@ getArkServerSetting() {
   if [ -n "${!varname}" ]; then
     echo "${!varname}"
   else
-    local val="$('/^\[ServerSettings\]/,/^\[.*\]/{s/^'"$1"'[[:space:]]*=[[:space:]]*//p;}' "${arkserverroot}/ShooterGame/Saved/Config/LinuxServer/GameUserSettings.ini")"
+    local val="$(tr -d '\0\376\377' <"${arkserverroot}/ShooterGame/Saved/Config/LinuxServer/GameUserSettings.ini" | sed -n '/^\[ServerSettings\]/,/^\[.*\]/{s/^'"$1"'[[:space:]]*=[[:space:]]*//p;}' )"
     if [ -n "$val" ]; then
       echo "$val"
     else


### PR DESCRIPTION
The `sed -n` was missed, thus causing arkmanager to be unable
to get the password or RCON port from GameUserSettings.ini

Fixes: 30aea93bd6572df640d04951617bbe477571dea7

This should fix #314 