### PR TITLE
Wait for SteamCMD to download mod

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -930,7 +930,7 @@ doDownloadMod(){
   while true; do
     ./$steamcmdexec +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} +workshop_download_item $mod_appid $modid +quit
     if [ ! -d "$moddldir" ]; then break; fi
-    local newsize="`du -s "$moddldir" | cut -f1`"
+    local newsize="`du -s "$moddldir/.." | cut -f1`"
     if [ $newsize -eq $dlsize ]; then break; fi
     dlsize=$newsize
   done


### PR DESCRIPTION
When `workshop_download_item` is executed, the Steam API will download not just the specified mod, but also every other mod that has ever been installed by that SteamCMD instance.
Wait for those to download and update when downloading the mod.