### PR TITLE
Add --saveworld to stop and restart; fix useconfig

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1651,6 +1651,10 @@ while true; do
       echo "   --backup           Takes a backup of the save files before updating"
       echo "   --downloadonly     Download the mod and/or server update without applying it"
       echo "                      Requires arkStagingDir be set to a staging directory on the same filesystem as the server"
+      echo
+      echo "stop and restart commands take the below options:"
+      echo "   --warn             Warn players before shutting down the server"
+      echo "   --saveworld        Saves world before shutdown"
       exit 1
     ;;
     *)

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1605,7 +1605,7 @@ while true; do
       doUninstallTools
     ;;
     useconfig)
-      useConfig "$2"
+      useConfig "${args[0]}"
       shift
     ;;
     --version)

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -685,6 +685,9 @@ doStop() {
     if [ " $* " =~ " --warn " ]; then
       doWarn "$1"
     fi
+    if [ " $* " =~ " --saveworld " ]; then
+      doSaveWorld
+    fi
     tput sc
     echo "Stopping server..."
     echo "`timestamp`: stopping" >> "$logdir/$arkmanagerLog"


### PR DESCRIPTION
448945a was created in response to a comment on c13afcb.
de298e8 fixes a mistake where the useconfig command wasn't updated in 6606ed3.
73a8593 adds the new options to stop and restart to the help output.
