### PR TITLE
Fix annoying syntax highlighting issue

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -491,7 +491,7 @@ function isTheServerOnline(){
 
   # If the Steam server response contains "addr": "$ip:$port",
   # then the server has registered with the Steam master server
-  if [[ "$serverresp" =~ \"addr\":\ \"([^\"]*):([0-9]*)\" ]]; then
+  if [[ "$serverresp" =~ "\"addr\": \""([^\"]*):([0-9]*)"\"" ]]; then
     return 0
   else
     return 1


### PR DESCRIPTION
Fixes an annoying syntax highlighting issue where everything from the line patched in this commit to the end is syntax highlighted as if it is in a multi-line string.