### PR TITLE
Have systemd (and upstart) run the script as the user

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -215,7 +215,7 @@ else
         cp systemd/arkmanager.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         cp systemd/arkmanager@.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
-        sed -i "s|=/usr/bin/|=${BINDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
+        sed -i "s|=/usr/bin/|=${BINDIR}/|;s|=steam$|=${steamcmd_user}|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
         if [ -z "${INSTALL_ROOT}" ]; then
           systemctl daemon-reload
           systemctl enable arkmanager.service
@@ -243,7 +243,7 @@ else
         cp systemd/arkmanager.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
         cp systemd/arkmanager@.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
-        sed -i "s|=/usr/bin/|=${BINDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
+        sed -i "s|=/usr/bin/|=${BINDIR}/|;s|=steam$|=${steamcmd_user}|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
         if [ -z "${INSTALL_ROOT}" ]; then
           systemctl daemon-reload
           systemctl enable arkmanager.service
@@ -277,7 +277,7 @@ else
       cp systemd/arkmanager.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
       sed -i "s|=/usr/libexec/arkmanager/|=${LIBEXECDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager.service"
       cp systemd/arkmanager@.service "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
-      sed -i "s|=/usr/bin/|=${BINDIR}/|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
+      sed -i "s|=/usr/bin/|=${BINDIR}/|;s|=steam$|=${steamcmd_user}|" "${INSTALL_ROOT}/etc/systemd/system/arkmanager@.service"
       if [ -z "${INSTALL_ROOT}" ]; then
         systemctl daemon-reload
         systemctl enable arkmanager.service

--- a/tools/systemd/arkmanager@.service
+++ b/tools/systemd/arkmanager@.service
@@ -2,5 +2,6 @@
 Description=Daemon to start an ark server instance
 
 [Service]
+User=steam
 ExecStart=/usr/bin/arkmanager useconfig %i run
 Type=simple

--- a/tools/upstart/arkmanager-instance.conf
+++ b/tools/upstart/arkmanager-instance.conf
@@ -2,6 +2,8 @@ description "ARK Server Tools service"
 
 instance $service
 
+setuid steam
+
 env DAEMON="/usr/bin/arkmanager"
 
 exec "$DAEMON" useconfig $service run


### PR DESCRIPTION
Have systemd and upstart directly run the script as the user specified during install.

Previously, they were monitoring and controlling the outer process running as root.  Thus stopping the service may not have worked under systemd or upstart.