### PR TITLE
Fix mod updating re-downloading mod

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -146,7 +146,6 @@ export TERM=${TERM:-dumb}
 arkmanagerLog="arkmanager.log"  # here are logged the actions performed by arkmanager
 arkserverLog="arkserver.log"    # here is logged the output of ShooterGameServer
 
-progressDisplayType="${progressDisplayType:-spinner}"
 appid="${appid:-376030}"
 mod_appid="${mod_appid:-346110}"
 arkautorestartfile="${arkautorestartfile:-ShooterGame/Saved/.autorestart}"
@@ -158,6 +157,7 @@ if [ "$steamcmd_user" == "--me" ]; then
 else
   install_datadir="${install_datadir:-${install_bindir%/*}/share/arkmanager}"
 fi
+
 
 #---------------------
 # functions
@@ -366,6 +366,13 @@ function runSteamCMDspinner(){
     runSteamCMD "$@"
     return $?
   else
+    if [ -z "$progressDisplayType" ]; then
+      if stty <&1 >/dev/null 2>&1; then
+        progressDisplayType=spinner
+      else
+        progressDisplayType=dots
+      fi
+    fi
     runSteamCMD "$@" >/dev/null 2>&1 &
     local scpid=$!
     local pos=0

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -146,6 +146,7 @@ export TERM=${TERM:-dumb}
 arkmanagerLog="arkmanager.log"  # here are logged the actions performed by arkmanager
 arkserverLog="arkserver.log"    # here is logged the output of ShooterGameServer
 
+progressDisplayType="${progressDisplayType:-spinner}"
 appid="${appid:-376030}"
 mod_appid="${mod_appid:-346110}"
 arkautorestartfile="${arkautorestartfile:-ShooterGame/Saved/.autorestart}"
@@ -368,11 +369,14 @@ function runSteamCMDspinner(){
     runSteamCMD "$@" >/dev/null 2>&1 &
     local scpid=$!
     local pos=0
-    local spinner=( '-' '/' '|' '\' )
+    local spinner=( '\b-' '\b/' '\b|' '\b\\' )
+    if [ "$progressDisplayType" == "dots" ]; then
+      spinner=( '.' )
+    fi
     echo -n ' ...  '
     while kill -0 $scpid 2>/dev/null; do
-      printf "\b%c" "${spinner[$pos]}"
-      (( pos = (pos + 1) % 4 ))
+      echo -ne "${spinner[$pos]}"
+      (( pos = (pos + 1) % ${#spinner[*]} ))
       sleep 0.5
     done
     echo -ne '\b \b'
@@ -1703,6 +1707,12 @@ while true; do
       ;;
       --verbose)
         verbose=1
+      ;;
+      --dots)
+        progressDisplayType=dots
+      ;;
+      --spinner)
+        progressDisplayType=spinner
       ;;
       --*)
         options+=( "$1" )

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1153,10 +1153,9 @@ getModIds(){
 doDownloadMod(){
   local modid=$1
   local modsrcdir="$steamcmdroot/steamapps/workshop/content/$mod_appid/$modid"
-  local moddldir="$steamcmdroot/steamapps/workshop/downloads/$mod_appid/$modid"
-  local dlsize=0
+  local moddldir="$steamcmdroot/steamapps/workshop/downloads/$mod_appid"
   cd "$steamcmdroot"
-  rm "$steamcmdroot/steamapps/workshop/appworkshop_${mod_appid}.acf" 2>/dev/null
+  retries=10
 
   while true; do
     echo -n "Downloading mod $modid"
@@ -1166,14 +1165,14 @@ doDownloadMod(){
       break
     else
       echo
-      echo "Checking mod $modid"
-      if [ ! -d "$moddldir" ]; then break; fi
-      local newsize="`du -s "$moddldir/.." | cut -f1`"
-      if [ $newsize -eq $dlsize ]; then 
-        echo "Mod $modid update not progressing - aborting"
-        return 1
+      if [ ! -d "$moddldir" ]; then
+        echo "Mod $modid download failed"
+        break
       fi
-      dlsize=$newsize
+      (( retries = retries - 1 ))
+      if (( retries <= 0 )); then
+        echo "Retries exhausted"
+      fi
       echo "Mod $modid not fully downloaded - retrying"
     fi
   done


### PR DESCRIPTION
Give up on trying to prevent steamcmd from updating every other workshop item it has downloaded.  Instead, give it a certain number of retries, and check if the app's workshop downloads directory exists.

This should fix #382.

c1a1dc7 also adds the ability to choose whether to show progress using dots or a spinner.
65c9233 defaults to using dots when the output is not a terminal - e.g. when output is going to a log file.