### PR TITLE
Replace empty server response with "Command processed"

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -320,7 +320,11 @@ rconcmd() {
     auth($socket, $password);
     sendpkt($socket, 2, 2, $command);
     my ($resid, $restype, $rcvbody) = recvpkt($socket);
-    print $rcvbody, "\n";
+    if ($rcvbody == "Server received, But no response!!") {
+      print "Command processed\n";
+    } else {
+      print $rcvbody, "\n";
+    }
     ' "$(getRconPort)" "${ark_MultiHome:-127.0.0.1}" "$adminpass" "$1"
 }
 
@@ -342,7 +346,7 @@ doExitServer() {
 # Broadcast message
 #
 doBroadcast(){
-  rconcmd "broadcast $1" >/dev/null
+  rconcmd "broadcast $1"
 }
 
 #


### PR DESCRIPTION
Replaces the `Server received, But no response!!` return from an RCON command with `Command processed`.