### PR TITLE
Fix typo in useConfig

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1646,7 +1646,7 @@ useConfig() {
       break
     fi
   done
-  if [ -a "$configfile" ]; then
+  if [ -z "$configfile" ]; then
     echo "Error: config file ${configfile} does not exist"
     exit 1
   fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1647,7 +1647,11 @@ useConfig() {
     fi
   done
   if [ -z "$configfile" ]; then
-    echo "Error: config file ${configfile} does not exist"
+    echo "Error: no config files for instance $1"
+    exit 1
+  fi
+  if [ ! -f "$configfile" ]; then
+    echo "Error: config file $configfile does not exist"
     exit 1
   fi
   source "$configfile"


### PR DESCRIPTION
Fixes: e48bd5b830a16fc5f30deb19a880b9443705259b Add configfile name to
list-instances

This should fix #414