### PR TITLE
Fix typo when comparing strings

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -320,7 +320,7 @@ rconcmd() {
     auth($socket, $password);
     sendpkt($socket, 2, 2, $command);
     my ($resid, $restype, $rcvbody) = recvpkt($socket);
-    if ($rcvbody == "Server received, But no response!!") {
+    if ($rcvbody eq "Server received, But no response!!") {
       print "Command processed\n";
     } else {
       print $rcvbody, "\n";


### PR DESCRIPTION
Perl uses `eq` to compare strings, not `==`.

Fixes 653e934268c876ac17bafa31998b9bb67c44abb6 Replace empty server
response with "Command processed"

This should fix #417