### PR TITLE
Add Blob SHA to --version output

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1796,6 +1796,7 @@ while true; do
       if [ -n "${arkstCommit}" ]; then
         echo "Commit: ${arkstCommit:0:7}"
       fi
+      echo "Blob SHA: $( (echo -ne "blob $(stat -c "%s" "$0")\0"; sed "s@^arkstCommit=.*@arkstCommit=''@" "$0") | sha1sum | cut -d' ' -f1)"
       exit 1
     ;;
     -h|--help)


### PR DESCRIPTION
This should make it possible to determine the arkmanager
version when it hasn't been installed using the netinstall
script.