### PR TITLE
Use serverMapModId to set map name and MapModID option

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -593,7 +593,17 @@ doRun() {
   arkserveropts="$serverMap"
 
   if [ -n "$serverMapModId" ]; then
-    arkserveropts="-MapModID=$serverMapModId"
+    serverMap="$(perl -e '
+      my $data;
+      { local $/; $data = <>; }
+      my $mapnamelen = unpack("@0 L<", $data);
+      my $mapname = substr($data, 4, $mapnamelen - 1);
+      $mapnamelen += 4;
+      my $mapfilelen = unpack("@" . ($mapnamelen + 4) . " L<", $data);
+      my $mapfile = substr($data, $mapnamelen + 8, $mapfilelen - 1);
+      print $mapfile;
+    ' <"${arkserverroot}/ShooterGame/Content/Mods/${serverMapModId}/mod.info")"
+    arkserveropts="${serverMap}?MapModID=${serverMapModId}"
   fi
 
   if [ -z "$arkserveropts" ]; then


### PR DESCRIPTION
It appears that putting the `-MapModID=<modid>` option in place of the map name no longer works.  Instead one must specify both the map name and the map mod ID.

This uses the serverMapModId setting to get the map name from the mod, and set the `MapModID` option to the mod id.

This should fix #437 and #436