### PR TITLE
Fixes

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -238,6 +238,37 @@ instances.
 `status`::
     Prints the status of the ARK server
 
+`install-cronjob <command>`::
+    Installs a cron job that executes the specified command.
+    This accepts any of the options the specified command accepts,
+    as well as the following options.  In order to specify an
+    argument to the command (e.g. to the `broadcast` command),
+    use the `--arg=<arg>` option.
+
+    `--daily`;;
+        The command should be executed daily
+
+    `--hourly`;;
+        The command should be executed hourly
+
+    `--hour=<hour>`;;
+        Specifies one or more hours when the command should execute.
+        This is the hour field of the cron job.
+
+    `--minute=<minute>`;;
+        Specifies one or more minutes of the hour when the command
+        should execute.  This is the minute field of the cron job.
+
+    `--enable-output`;;
+        Enables the output from the command - the cron daemon usually
+        emails this to the user specified in the cron configuration
+
+    `--arg=<arg>`;;
+        Specifies an argument to pass to the command
+
+`remove-cronjob <command>`::
+    Removes a cron job previously installed by `install-cronjob`
+
 Configuration files
 -------------------
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -211,6 +211,10 @@ instances.
         Downloads the update but does not apply it.  Only has effect
         if a staging directory is set.
 
+`cancelshutdown`::
+    Cancels a pending update / shutdown / restart that was run with
+    the `--warn` option
+
 `checkupdate`::
     Checks if an ARK server update is available
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -152,6 +152,9 @@ instances.
     `--warn`;;
         Warns any connected players that the server is going down
 
+    `--warnreason`;;
+        Gives a reason for the shutdown.  Defaults to `maintenance`
+
     `--saveworld`;;
         Saves the world using `saveworld` - usually not
         necessary, as server usually saves the world on a graceful
@@ -160,6 +163,9 @@ instances.
 `restart`::
     Runs the `stop` command followed by the `restart` command.
     Accepts and passes the options for those commands
+
+    `--warnreason`;;
+        Gives a reason for the restart.  Defaults to `a restart`
 
 `install`::
     Downloads and installs (or validates an existing install) of
@@ -351,6 +357,32 @@ The following options can be overridden on a per-instance basis:
 `msgWarnShutdownSeconds`::
     Templated messages for warnings, where `%d` is replaced with the
     number of minutes / seconds before the update / restart / shutdown
+
+`msgWarnReason`::
+`msgTimeMinutes`::
+`msgTimeSeconds`::
+`msgReasonUpdateApp`::
+`msgReasonUpdateMod`::
+`msgReasonUpdateAppMod`::
+`msgReasonRestart`::
+`msgReasonShutdown`::
+    Alternative templated messages for warnings with the following
+    replacement parameters:
+
+    `{reason}`;;
+        Valid in `msgWarnReason`, replaced at runtime with the appropriate `msgReason*` template
+
+    `{time}`;;
+        Valid in `msgWarnReason`, replaced at runtime with the appropriate `msgTime*` template
+
+    `{modnamesupdate}`;;
+        Valid in `msgReason*Mod`, replaced at runtime with a comma-delimited list of updated mod names
+
+    `{minutes}`;;
+        Valid in `msgTimeMinutes`, replaced at runtime with minutes remaining until shutdown
+
+    `{seconds}`;;
+        Valid in `msgTimeSeconds`, replaced at runtime with seconds remaining until shutdown
 
 `logdir`::
     Specifies where to store log files

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -816,10 +816,24 @@ doStartAll(){
 #
 doStop() {
   if isTheServerRunning; then
-    if [[ " $* " =~ " --warn " ]]; then
-      doWarn "$1"
+    local stopreason="$1"
+    local dowarn=
+    local warnreason=
+    local dosave=
+    shift
+
+    for arg in "$@"; do
+      case "$arg" in
+        --warn) dowarn=1; ;;
+        --warnreason=*) warnreason="${arg#*=}"; ;;
+        --saveworld) dosave=1; ;;
+      esac
+    done
+
+    if [[ -n "$dowarn" ]]; then
+      doWarn "$1" "$warnreason"
     fi
-    if [[ " $* " =~ " --saveworld " ]]; then
+    if [[ -n "$dosave" ]]; then
       doSaveWorld
     fi
     tput sc
@@ -1237,7 +1251,7 @@ doUpdate() {
       doSaveWorld
     fi
 
-    doStop
+    doStop update
 
     # If user wants to back-up, we do it here.
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -701,8 +701,6 @@ doRun() {
   arkserveropts="${arkserveropts}?listen"
   # run the server in background
   echo "`timestamp`: start"
-  # set max open files limit before we start the server
-  ulimit -n $maxOpenFiles
 
   serverpid=0
   restartserver=1

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1348,23 +1348,31 @@ doExtractMod(){
       fi
     done
 
+    modname="$(curl -s "http://steamcommunity.com/sharedfiles/filedetails/?id=${modid}" | sed -n 's|^.*<div class="workshopItemTitle">\([^<]*\)</div>.*|\1|p')"
+
+    rm "${moddestdir}/.mod"
+
     perl -e '
       my $data;
       { local $/; $data = <STDIN>; }
       my $mapnamelen = unpack("@0 L<", $data);
       my $mapname = substr($data, 4, $mapnamelen - 1);
-      $mapnamelen += 4;
-      my $mapfilelen = unpack("@" . ($mapnamelen + 4) . " L<", $data);
-      my $mapfile = substr($data, $mapnamelen + 8, $mapfilelen);
-      print pack("L< L< L< Z8 L< C L< L<", $ARGV[0], 0, 8, "ModName", 1, 0, 1, $mapfilelen);
-      print $mapfile;
+      my $mapfilelen = unpack("@" . ($mapnamelen + 8) . " L<", $data);
+      my $mapfile = substr($data, $mapnamelen + 12, $mapfilelen);
+      my $modname = $ARGV[1] . "\x00";
+      my $modnamelen = length($modname);
+      my $modpath = "../../../ShooterGame/Content/Mods/" . $ARGV[0] . "\x00";
+      my $modpathlen = length($modpath);
+      print pack("L< L< L< Z$modnamelen L< Z$modpathlen L< L< Z$mapfilelen",
+        $ARGV[0], 0, $modnamelen, $modname, $modpathlen, $modpath,
+	1, $mapfilelen, $mapfile);
       print "\x33\xFF\x22\xFF\x02\x00\x00\x00\x01";
-    ' $modid <"$moddestdir/mod.info" >"$moddestdir/.mod"
+    ' $modid "$modname" <"$moddestdir/mod.info" >"${moddestdir}.mod"
 
     if [ -f "$moddestdir/modmeta.info" ]; then
-      cat "$moddestdir/modmeta.info" >>"$moddestdir/.mod"
+      cat "$moddestdir/modmeta.info" >>"${moddestdir}.mod"
     else
-      echo -ne '\x01\x00\x00\x00\x08\x00\x00\x00ModType\x00\x02\x00\x00\x001\x00' >>"$moddestdir/.mod"
+      echo -ne '\x01\x00\x00\x00\x08\x00\x00\x00ModType\x00\x02\x00\x00\x001\x00' >>"${moddestdir}.mod"
     fi
 
     echo "$modbranch" >"$moddestdir/.modbranch"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -577,7 +577,7 @@ function numPlayersConnected(){
     my $sockaddr = pack_sockaddr_in($port, inet_aton($ARGV[1]));
     send($socket, "\xff\xff\xff\xffTSource Engine Query\x00", 0, $sockaddr);
     my $data = "";
-    recv($socket, $data, 1400, 0) or (print "0" and exit(1));
+    recv($socket, $data, 1400, 0) or (print "-1" and exit(1));
     my ($servername, $mapname, $game, $fullname, $rest) = split(/\x00/, substr($data, 6), 5);
     my $players = ord(substr($rest, 2, 1));
     print "$players\n";

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -158,6 +158,7 @@ else
   install_datadir="${install_datadir:-${install_bindir%/*}/share/arkmanager}"
 fi
 
+declare -A modsrcdirs
 
 #---------------------
 # functions
@@ -366,8 +367,11 @@ function runSteamCMD(){
 
 function runSteamCMDspinner(){
   if [ -n "$verbose" ]; then
-    echo
-    runSteamCMD "$@"
+    if command >&3; then
+      runSteamCMD "$@" | tee /dev/fd/3
+    else
+      runSteamCMD "$@"
+    fi
     return $?
   else
     if [ -z "$progressDisplayType" ]; then
@@ -377,7 +381,11 @@ function runSteamCMDspinner(){
         progressDisplayType=dots
       fi
     fi
-    runSteamCMD "$@" >/dev/null 2>&1 &
+    if command >&3; then
+      runSteamCMD "$@" >&3 &
+    else
+      runSteamCMD "$@" >/dev/null &
+    fi
     local scpid=$!
     local pos=0
     local spinner=( '\b-' '\b/' '\b|' '\b\\' )
@@ -394,6 +402,12 @@ function runSteamCMDspinner(){
     wait $scpid
     return $?
   fi
+}
+
+function runSteamCMDspinnerSubst(){
+  local fd="$1"
+  shift
+  runSteamCMDspinner "$@" 3>&1 >/dev/fd/${fd}
 }
 
 #
@@ -1223,9 +1237,10 @@ doDownloadMod(){
 
   while true; do
     echo -n "Downloading mod $modid"
-    runSteamCMDspinner +workshop_download_item $mod_appid $modid
+    local output=$(runSteamCMDspinnerSubst 5 +workshop_download_item $mod_appid $modid) 5>&1
     result=$?
     if [ $result -eq 0 ]; then
+      modsrcdir="$(echo "$output" | sed -n 's@^Success. Downloaded item [0-9][0-9]* to "\([^"]*\)" .*@\1@p')"
       break
     else
       echo
@@ -1243,6 +1258,7 @@ doDownloadMod(){
 
   if [ -f "$modsrcdir/mod.info" ]; then
     echo "Mod $modid downloaded"
+    modsrcdirs[$modid]="$modsrcdir"
     return 0
   else
     echo "Mod $modid was not successfully downloaded"
@@ -1267,6 +1283,10 @@ isModUpdateNeeded(){
   local modsrcdir="$steamcmdroot/steamapps/workshop/content/$mod_appid/$modid"
   local moddestdir="$arkserverroot/ShooterGame/Content/Mods/$modid"
   local modbranch="${mod_branch:-Windows}"
+
+  if [ -n "${modsrcdirs[$modid]}" ]; then
+    modsrcdir="${modsrcdirs[$modid]}"
+  fi
 
   for varname in "${!mod_branch_@}"; do
     if [ "mod_branch_$modid" == "$varname" ]; then
@@ -1314,6 +1334,10 @@ doExtractMod(){
   local modsrcdir="$steamcmdroot/steamapps/workshop/content/$mod_appid/$modid"
   local moddestdir="$arkserverroot/ShooterGame/Content/Mods/$modid"
   local modbranch="${mod_branch:-Windows}"
+
+  if [ -n "${modsrcdirs[$modid]}" ]; then
+    modsrcdir="${modsrcdirs[$modid]}"
+  fi
 
   for varname in "${!mod_branch_@}"; do
     if [ "mod_branch_$modid" == "$varname" ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1732,6 +1732,22 @@ while true; do
   shift
   nrarg=0
 
+  # Handle global options
+  case "$command" in
+    --verbose)
+      verbose=1
+      continue
+    ;;
+    --dots)
+      progressDisplayType=dots
+      continue
+    ;;
+    --spinner)
+      progressDisplayType=spinner
+      continue
+    ;;
+  esac
+
   # get the number of arguments for commands that take arguments
   case "$command" in
     installmod) nrarg=1; ;;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -593,7 +593,17 @@ doRun() {
   arkserveropts="$serverMap"
 
   if [ -n "$serverMapModId" ]; then
-    arkserveropts="-MapModID=$serverMapModId"
+    serverMap="$(perl -e '
+      my $data;
+      { local $/; $data = <>; }
+      my $mapnamelen = unpack("@0 L<", $data);
+      my $mapname = substr($data, 4, $mapnamelen - 1);
+      $mapnamelen += 4;
+      my $mapfilelen = unpack("@" . ($mapnamelen + 4) . " L<", $data);
+      my $mapfile = substr($data, $mapnamelen + 8, $mapfilelen - 1);
+      print $mapfile;
+    ' <"${arkserverroot}/ShooterGame/Content/Mods/${serverMapModId}/mod.info")"
+    arkserveropts="${serverMap}?MapModID=${serverMapModId}"
   fi
 
   if [ -z "$arkserveropts" ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1561,6 +1561,64 @@ doBackup(){
   fi
 }
 
+#
+# Install a cron job to execute a particular command
+#
+doInstallCronJob(){
+  hour='*'
+  minute='0'
+  cmdopts="${arkCronExtraOpts}"
+  cmdargs=""
+  output=">/dev/null 2>&1"
+  command="$1"
+  shift
+
+  for opt in "$@"; do
+    case "$opt" in
+      --daily)
+      ;;
+      --hourly)
+        hour='*'
+      ;;
+      --hour=*)
+        hour="${opt#--hour=}"
+      ;;
+      --minute=*)
+        minute="${opt#--minute=}"
+      ;;
+      --enable-output)
+        output=
+      ;;
+      --arg=*)
+        cmdargs="${cmdargs} $(printf "%q" "${opt#--opt=}")"
+      ;;
+      --*)
+        cmdopts="${cmdopts} $(printf "%q" "${opt}")"
+      ;;
+      *)
+        cmdargs="${args} $(printf "%q" "${opt}")"
+      ;;
+    esac
+  done
+
+  cronjob="${minute} ${hour} * * * arkmanager --cronjob ${command} @${instance} ${cmdopts} --args ${cmdargs} -- ${output}"
+
+  (crontab -l | \
+    sed -e "/ [*] [*] [*] arkmanager --cronjob ${command} @${instance} /d";
+    echo "${cronjob}" ) | \
+    crontab -
+}
+
+#
+# Removes an installed cron job
+#
+doRemoveCronJob(){
+  command="$1"
+
+  crontab -l | \
+    sed -e "/ [*] [*] [*] arkmanager --cronjob ${command} @${instance} /d" | \
+    crontab -
+}
 
 #
 # Print the status of the server (running? online? version?)
@@ -1697,6 +1755,8 @@ showUsage() {
   echo "installmod <modid>    Installs a mod from the Steam workshop"
   echo "uninstallmod <modid>  Removes the mod from the Mods directory"
   echo "reinstallmod <modid>  Removes and re-installs a mod in the Mods directory"
+  echo "install-cronjob <cmd> Adds a cron job using the specified command"
+  echo "remove-cronjob <cmd>  Removes a cron job that used the specified command"
   echo "restart               Stops the server and then starts it"
   echo "run                   Runs the server without daemonizing"
   echo "start                 Starts the server"
@@ -1746,6 +1806,10 @@ while true; do
       progressDisplayType=spinner
       continue
     ;;
+    --cronjob)
+      inCronJob=true
+      continue
+    ;;
   esac
 
   # get the number of arguments for commands that take arguments
@@ -1756,6 +1820,8 @@ while true; do
     broadcast) nrarg=1; ;;
     rconcmd) nrarg=1; ;;
     useconfig) nrarg=1; ;;
+    install-cronjob) nrarg=1; ;;
+    remove-cronjob) nrarg=1; ;;
   esac
 
   # Enumerate the options and arguments
@@ -1911,6 +1977,12 @@ while true; do
       ;;
       status)
         printStatus
+      ;;
+      install-cronjob)
+        doInstallCronJob "${args[@]}" "${options[@]}"
+      ;;
+      remove-cronjob)
+        doRemoveCronJob "${args[@]}"
       ;;
       *)
         echo -n "arkmanager v${arkstVersion}: unknown command '$command' specified"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1493,18 +1493,57 @@ doBackup(){
     savedir="${ark_AltSaveDirectoryName}"
   fi
 
+  saverootdir="${arkserverroot}/ShooterGame/Saved"
+  savedcfgdir="${saverootdir}/Config/LinuxServer"
+  savedir="${savedrootdir}/${savedir}"
+
+  # Check for the (unlikely) case that the case of the
+  # saved ark directory is screwed up
+  if [ ! -d "${savedir}" ]; then
+    cisavedir="$(find "${arkserverroot}" -ipath "${savedir}" | head -n1)"
+
+    if [ -n "$cisavedir" ]; then
+      echo -e "  ${NORMAL}[  ${YELLOW}WARN${NORMAL}  ] Saved arks directory capitalization is inconsistent"
+      savedir="${cisavedir}"
+    else
+      echo -e "  ${NORMAL}[ ${RED}ERROR${NORMAL}  ] Saved arks directory does not exist"
+      return 1
+    fi
+  fi
+
   # ARK server uses Write-Unlink-Rename
   echo -ne "${NORMAL} Copying ARK world file "
-  cp -p "${arkserverroot}/ShooterGame/Saved/${savedir}/${serverMap##*/}.ark" "${backupdir}/${serverMap##*/}.ark"
-  if [ ! -f "${backupdir}/${serverMap##*/}.ark" ]; then
+
+  # Take into account screwed up casing of saved ark files
+  # in some environments
+  mapfile="$(find "${savedir}" -iname "${serverMap##*/}.ark" | head -n1)"
+
+  if [ -z "$mapfile" ]; then
     sleep 2
-    cp -p "${arkserverroot}/ShooterGame/Saved/${savedir}/${serverMap##*/}.ark" "${backupdir}/${serverMap##*/}.ark"
+    mapfile="$(find "${savedir}" -iname "${serverMap##*/}.ark" | head -n1)"
   fi
+
   # If both attempts fail, server may have
   # crashed between unlink and rename
-  if [ ! -f "${backupdir}/${serverMap##*/}.ark" ]; then
-    cp -p "${arkserverroot}/ShooterGame/Saved/${savedir}/${serverMap##*/}.tmp" "${backupdir##*/}/${serverMap##*/}.ark"
+  if [ -z "$mapfile" ]; then
+    mapfile="$(find "${savedir}" -iname "${serverMap##*/}.tmp" | head -n1)"
   fi
+
+  # If neither the ark nor the tmp file exists, then the
+  # map name may be incorrect.  Try to get any ark or tmp
+  # file in the saved arks directory
+  if [ -z "$mapfile" ]; then
+    mapfile="$(find "${savedir}" -iname "*.ark" | head -n1)"
+
+    if [ -z "$mapfile" ]; then
+      mapfile="$(find "${savedir}" -iname "*.tmp" | head -n1)"
+    fi
+  fi
+
+  if [ -f "${mapfile}" ]; then
+    cp -p "${mapfile}" "${backupdir}/${serverMap##*/}.ark"
+  fi
+
   if [ -f "${backupdir}/${serverMap##*/}.ark" ]; then
     echo -e "${NORMAL}\e[68G[   ${GREEN}OK${NORMAL}   ]"
   else
@@ -1516,7 +1555,7 @@ doBackup(){
   # ARK server uses a non-blocking lock and will
   # fail to update the file if the lock fails.
   echo -e "${NORMAL} Copying ARK profile files"
-  for f in "${arkserverroot}/ShooterGame/Saved/${savedir}/"*.arkprofile; do
+  for f in "${savedir}/"*.arkprofile; do
     echo -ne "${NORMAL}   ${f##*/} "
     cp -p "${f}" "${backupdir}/${f##*/}"
     if [ ! -s "${backupdir}/${f##*/}" ]; then
@@ -1537,7 +1576,7 @@ doBackup(){
 
   # ARK server uses Lock-Truncate-Write-Unlock
   echo -e "${NORMAL} Copying ARK tribe files "
-  for f in "${arkserverroot}/ShooterGame/Saved/${savedir}/"*.arktribe; do
+  for f in "${savedir}/"*.arktribe; do
     echo -ne "${NORMAL}   ${f##*/} "
     cp -p "${f}" "${backupdir}/${f##*/}"
     if [ ! -s "${backupdir}/${f##*/}" ]; then
@@ -1558,7 +1597,7 @@ doBackup(){
 
   # ARK server uses Lock-Truncate-Write-Unlock
   echo -ne "${NORMAL} Copying GameUserSettings.ini "
-  cp -p "${arkserverroot}/ShooterGame/Saved/Config/LinuxServer/GameUserSettings.ini" "${backupdir}/GameUserSettings.ini"
+  cp -p "${savedcfgdir}/GameUserSettings.ini" "${backupdir}/GameUserSettings.ini"
   if [ ! -s "${backupdir}/GameUserSettings.ini" ]; then
     sleep 2
     cp -p "${f}" "${backupdir}/${f##*/}"
@@ -1572,7 +1611,7 @@ doBackup(){
    
    echo -ne "${NORMAL} Copying Game.ini "
   
-  cp -p "${arkserverroot}/ShooterGame/Saved/Config/LinuxServer/Game.ini" "${backupdir}/Game.ini"
+  cp -p "${savedcfgdir}/Game.ini" "${backupdir}/Game.ini"
   if [ ! -s "${backupdir}/Game.ini" ]; then
     sleep 2
     cp -p "${f}" "${backupdir}/${f##*/}"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -897,117 +897,206 @@ doInstall() {
 }
 
 #
+# Formats a warning message based on replacement strings
+#
+printWarnMessage(){
+  local msg
+  if [ -n "$msgWarnReason" ]; then
+    local reason
+    local msgtime
+    if [ "$3" == "minutes" ]; then
+      if [ -n "$msgTimeMinutes" ]; then
+        msgtime="${msgTimeMinutes//\{minutes\}/$4}"
+      else
+        msgtime="$4 minutes"
+      fi
+    else
+      if [ -n "$msgTimeSeconds" ]; then
+        msgtime="${msgTimeSeconds//\{seconds\}/$4}"
+      else
+        msgtime="$4 seconds"
+      fi
+    fi
+    msg="${msgWarnReason//\{time\}/$msgtime}"
+    if [ "$1" == "update" ]; then
+      if [ -n "$appupdate" ]; then
+        if [ -n "$modupdate" ]; then
+          if [ -n "$msgReasonUpdateAppMod" ]; then
+            reason="$msgReasonUpdateMod"
+          else
+            reason="an update to the game and an update to mod(s) {modnamesupdated}"
+          fi
+        else
+          if [ -n "$msgReasonUpdateApp" ]; then
+            reason="$msgReasonUpdateApp"
+          else
+            reason="an update to the game"
+          fi
+        fi
+      elif [ -n "$modupdate" ]; then
+        if [ -n "$msgReasonUpdateMod" ]; then
+          reason="$msgReasonUpdateMod"
+        else
+          reason="an update to mod(s) {modnamesupdated}"
+        fi
+      fi
+    elif [ -n "$shutdownreason" ]; then
+      reason="$shutdownreason"
+    elif [ "$1" == "restart" ]; then
+      if [ -n "$msgReasonRestart" ]; then
+        reason="$msgReasonRestart"
+      else
+        reason="a restart"
+      fi
+    else
+      if [ -n "$msgReasonShutdown" ]; then
+        reason="$msgReasonShutdown"
+      else
+        reason="maintenance"
+      fi
+    fi
+    reason="${reason//\{modnamesupdated\}/${modnamesupdated}}"
+    msg="${msg//\{reason\}/${reason}}"
+    printf "%s\n" "$msg"
+  else
+    if [ "$1" == "update" ]; then
+      if [ "$3" == "minutes" ]; then
+        if [ -n "$msgWarnUpdateMinutes" ]; then
+          msg="${msgWarnUpdateMinutes//%d/$4}"
+        else
+          msg="This ARK server will shutdown for an update in $4 minutes"
+        fi
+      else
+        if [ -n "$msgWarnUpdateSeconds" ]; then
+          msg="${msgWarnUpdateSeconds//%d/$4}"
+        else
+          msg="This ARK server will shutdown for an update in $4 seconds"
+        fi
+      fi
+    elif [ "$1" == "restart" ]; then
+      if [ "$3" == "minutes" ]; then
+        if [ -n "$msgWarnRestartMinutes" ]; then
+          msg="${msgWarnRestartMinutes//%d/$4}"
+        else
+          msg="This ARK server will shutdown for a restart in $4 minutes"
+        fi
+      else
+        if [ -n "$msgWarnRestartSeconds" ]; then
+          msg="${msgWarnRestartSeconds//%d/$4}"
+        else
+          msg="This ARK server will shutdown for a restart in $4 seconds"
+        fi
+      fi
+    else
+      if [ "$3" == "minutes" ]; then
+        if [ -n "$msgWarnShutdownMinutes" ]; then
+          msg="${msgWarnShutdownMinutes//%d/$4}"
+        else
+          msg="This ARK server will shutdown in $4 minutes"
+        fi
+      else
+        if [ -n "$msgWarnShutdownSeconds" ]; then
+          msg="${msgWarnShutdownSeconds//%d/$4}"
+        else
+          msg="This ARK server will shutdown in $4 seconds"
+        fi
+      fi
+    fi
+  fi
+
+  doBroadcastWithEcho "$msg"
+}
+
+#
 # Waits for a configurable number of minutes before updating the server
 #
 doWarn(){
   cd "$arkserverroot"
 
-  local warnmsgmin
-  local warnmsgsec
-
-  if [ "$1" == "update" ]; then
-    if [ -n "$msgWarnUpdateMinutes" ]; then
-      warnmsgmin="$msgWarnUpdateMinutes"
-    else
-      warnmsgmin="This ARK server will shutdown for an update in %d minutes"
-    fi
-    if [ -n "$msgWarnUpdateSeconds" ]; then
-      warnmsgsec="$msgWarnUpdateSeconds"
-    else
-      warnmsgsec="This ARK server will shutdown for an update in %d seconds"
-    fi
-  elif [ "$1" == "restart" ]; then
-    if [ -n "$msgWarnRestartMinutes" ]; then
-      warnmsgmin="$msgWarnRestartMinutes"
-    else
-      warnmsgmin="This ARK server will shutdown for a restart in %d minutes"
-    fi
-    if [ -n "$msgWarnRestartSeconds" ]; then
-      warnmsgsec="$msgWarnRestartSeconds"
-    else
-      warnmsgsec="This ARK server will shutdown for a restart in %d seconds"
-    fi
-  else
-    if [ -n "$msgWarnShutdownMinutes" ]; then
-      warnmsgmin="$msgWarnShutdownMinutes"
-    else
-      warnmsgmin="This ARK server will shutdown in %d minutes"
-    fi
-    if [ -n "$msgWarnShutdownSeconds" ]; then
-      warnmsgsec="$msgWarnShutdownSeconds"
-    else
-      warnmsgsec="This ARK server will shutdown in %d seconds"
-    fi
-  fi
-
-  local pid=`getServerPID`
-  local sleeppid
-  if [ -n "$pid" ]; then
-    local warnmsg
-    local warnminutes=$(( arkwarnminutes ))
-    if (( warnminutes == 0 )); then
-      warnminutes=60
-    fi
-
-    local warnintervals=( 90 60 45 30 20 15 10 5 4 3 2 )
-
-    for warninterval in "${warnintervals[@]}"; do
-      if [ "`getServerPID`" != "$pid" ]; then
-        echo "Server has stopped.  Aborting $1"
-        return 1
+  (
+    update_cancelled(){
+      if [ -n "$msgUpdateCancelled" ]; then
+        msg="${msgUpdateCancelled//%s/$1}"
+      else
+        msg="Update cancelled by operator ($1)"
       fi
-      if (( warnminutes > warninterval )); then
-        sleep 1m &
+      doBroadcastWithEcho "${msg}"
+    }
+
+    trap "update_cancelled 'Ctrl+C'" SIGINT
+    trap "update_cancelled 'Terminated'" SIGTERM
+    trap "update_cancelled 'Connection Closed'" SIGHUP
+    trap "update_cancelled 'Quit'" SIGQUIT
+
+    local pid=`getServerPID`
+    local sleeppid
+    if [ -n "$pid" ]; then
+      local warnmsg
+      local warnminutes=$(( arkwarnminutes ))
+      if (( warnminutes == 0 )); then
+        warnminutes=60
+      fi
+
+      local warnintervals=( 90 60 45 30 20 15 10 5 4 3 2 )
+
+      for warninterval in "${warnintervals[@]}"; do
+        if [ "`getServerPID`" != "$pid" ]; then
+          echo "Server has stopped.  Aborting $1"
+          return 1
+        fi
+        if (( warnminutes >= warninterval )); then
+          sleep 1m &
+          sleeppid=$!
+          printWarnMessage "$1" "$2" "minutes" "$warnminutes"
+          for (( min = warnminutes - 1; min >= warninterval; min-- )); do
+            numplayers=$(numPlayersConnected)
+            echo "There are ${numplayers} players connected"
+            if (( (numplayers + 0) == 0 )); then
+              doBroadcastWithEcho "Nobody is connected.  Shutting down immediately"
+              return 0
+            fi
+            wait $sleeppid
+            if (( $min > $warninterval )); then
+              sleep 1m &
+              sleeppid=$!
+            fi
+          done
+          warnminutes=$warninterval
+        fi
+      done
+
+      local warnseconds=120
+      warnintervals=( 90 60 45 30 20 15 10 5 0 )
+      for warninterval in "${warnintervals[@]}"; do
+        sleep $(( warnseconds - warninterval ))s &
         sleeppid=$!
-        warnmsg="$(printf "$warnmsgmin" "$warnminutes")"
-        doBroadcastWithEcho "$warnmsg"
-        for (( min = warnminutes - 1; min >= warninterval; min-- )); do
+        if [ "`getServerPID`" != "$pid" ]; then
+          echo "Server has stopped.  Aborting update"
+          return 1
+        fi
+        printWarnMessage "$1" "$2" "seconds" "$warnseconds"
+        if (( warnseconds >= 20 )); then
           numplayers=$(numPlayersConnected)
           echo "There are ${numplayers} players connected"
           if (( (numplayers + 0) == 0 )); then
-            echo "Nobody is connected.  Shutting down immediately"
+            doBroadcastWithEcho "Nobody is connected.  Shutting down immediately"
             return 0
           fi
-          wait $sleeppid
-          if (( $min > $warninterval )); then
-            sleep 1m &
-            sleeppid=$!
-          fi
-        done
-        warnminutes=$warninterval
-      fi
-    done
-
-    local warnseconds=120
-    warnintervals=( 90 60 45 30 20 15 10 5 0 )
-    for warninterval in "${warnintervals[@]}"; do
-      sleep $(( warnseconds - warninterval ))s &
-      sleeppid=$!
-      if [ "`getServerPID`" != "$pid" ]; then
-        echo "Server has stopped.  Aborting update"
-        return 1
-      fi
-      warnmsg="$(printf "$warnmsgsec" "$warnseconds")"
-      doBroadcastWithEcho "$warnmsg"
-      if (( warnseconds >= 20 )); then
-        numplayers=$(numPlayersConnected)
-        echo "There are ${numplayers} players connected"
-        if (( (numplayers + 0) == 0 )); then
-          echo "Nobody is connected.  Shutting down immediately"
-          return 0
         fi
-      fi
-      wait $sleeppid
-      warnseconds=$warninterval
-    done
-  fi
+        wait $sleeppid
+        warnseconds=$warninterval
+      done
+    fi
 
-  if [ "`getServerPID`" != "$pid" ]; then
-    echo "Server has stopped.  Aborting $1"
-    return 1
-  fi
+    if [ "`getServerPID`" != "$pid" ]; then
+      echo "Server has stopped.  Aborting $1"
+      return 1
+    fi
 
-  return 0
+    return 0
+  )
+
+  return $?
 }
 
 #
@@ -1314,16 +1403,48 @@ isModUpdateNeeded(){
 }
 
 #
+# Get the name of the specified mod
+#
+getModName(){
+  local modid=$1
+  local modsrcdir="$steamcmdroot/steamapps/workshop/content/$mod_appid/$modid"
+
+  if [ -n "${modsrcdirs[$modid]}" ]; then
+    modsrcdir="${modsrcdirs[$modid]}"
+  fi
+
+  modname="$(curl -s "http://steamcommunity.com/sharedfiles/filedetails/?id=${modid}" | sed -n 's|^.*<div class="workshopItemTitle">\([^<]*\)</div>.*|\1|p')"
+
+  if [ -n "$modname" ]; then
+    echo "$modname"
+  else
+    perl -e '
+      my $data;
+      { local $/; $data = <STDIN>; }
+      my $mapnamelen = unpack("@0 L<", $data);
+      my $mapname = substr($data, 4, $mapnamelen - 1);
+      print $mapname
+    ' <"${modsrcdir}/mod.info"
+  fi
+}
+
+#
 # Checks if any installed or requested mods need to be updated
 #
 isAnyModUpdateNeeded(){
+  modnamesupdated=""
+  local ismodupdateneeded=1
   for modid in $(getModIds); do
     if isModUpdateNeeded $modid; then
-      return 0
+      ismodupdateneeded=0
+      if [ -n "$modnamesupdated" ]; then
+        modnamesupdated="${modnamesupdated}, "
+      fi
+      modnamesupdated="${modnamesupdated}$(getModName "$modid")"
     fi
   done
 
-  return 1
+  return $ismodupdateneeded
 }
 
 #

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -369,6 +369,9 @@ function runSteamCMD(){
 
 function runSteamCMDspinner(){
   if [ -n "$verbose" ]; then
+    printf "Executing"
+    printf " %q" "$steamcmdroot/$steamcmdexec" +@NoPromptForPassword 1 +login ${steamlogin:-anonymous} "$@" +quit
+    printf "\n"
     if command >&3; then
       runSteamCMD "$@" | tee /dev/fd/3
     else

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1397,7 +1397,11 @@ isModUpdateNeeded(){
     fi
   done
 
-  if [ \( ! -f "$moddestdir/.modbranch" \) ] || [ "$(<"$moddestdir/.modbranch")" != "$modbranch" ]; then
+  if [ -f "$moddestdir/.modbranch" ]; then
+    mv "$moddestdir/.modbranch" "$moddestdir/__arkmanager_modbranch__.info"
+  fi
+
+  if [ \( ! -f "$moddestdir/__arkmanager_modbranch__.info" \) ] || [ "$(<"$moddestdir/__arkmanager_modbranch__.info")" != "$modbranch" ]; then
     return 0
   fi
 
@@ -1480,7 +1484,11 @@ doExtractMod(){
     fi
   done
 
-  if [ \( ! -f "$moddestdir/.modbranch" \) ] || [ "$(<"$moddestdir/.modbranch")" != "$modbranch" ]; then
+  if [ -f "$moddestdir/.modbranch" ]; then
+    mv "$moddestdir/.modbranch" "$moddestdir/__arkmanager_modbranch__.info"
+  fi
+
+  if [ \( ! -f "$moddestdir/__arkmanager_modbranch__.info" \) ] || [ "$(<"$moddestdir/__arkmanager_modbranch__.info")" != "$modbranch" ]; then
     rm -rf "$moddestdir"
   fi
 
@@ -1590,7 +1598,7 @@ doExtractMod(){
       echo -ne '\x01\x00\x00\x00\x08\x00\x00\x00ModType\x00\x02\x00\x00\x001\x00' >>"${moddestdir}.mod"
     fi
 
-    echo "$modbranch" >"$moddestdir/.modbranch"
+    echo "$modbranch" >"$moddestdir/__arkmanager_modbranch__.info"
   fi
 }
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -126,6 +126,8 @@ if [ -f "${HOME}/.arkmanager.cfg" ]; then
     source "${HOME}/.arkmanager.cfg"
 fi
 
+cd "$HOME"
+
 lsof=lsof
 if [ -x /usr/sbin/lsof ]; then
   lsof=/usr/sbin/lsof

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1806,6 +1806,7 @@ while true; do
       if [ -n "${arkstCommit}" ]; then
         echo "Commit: ${arkstCommit:0:7}"
       fi
+      echo "Blob SHA: $( (echo -ne "blob $(stat -c "%s" "$0")\0"; sed "s@^arkstCommit=.*@arkstCommit=''@" "$0") | sha1sum | cut -d' ' -f1)"
       exit 1
     ;;
     -h|--help)

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1361,7 +1361,7 @@ doExtractMod(){
       my $mapname = substr($data, 4, $mapnamelen - 1);
       my $mapfilelen = unpack("@" . ($mapnamelen + 8) . " L<", $data);
       my $mapfile = substr($data, $mapnamelen + 12, $mapfilelen);
-      my $modname = $ARGV[1] . "\x00";
+      my $modname = ($ARGV[1] || $mapname) . "\x00";
       my $modnamelen = length($modname);
       my $modpath = "../../../ShooterGame/Content/Mods/" . $ARGV[0] . "\x00";
       my $modpathlen = length($modpath);

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -831,7 +831,9 @@ doStop() {
     done
 
     if [[ -n "$dowarn" ]]; then
-      doWarn "$1" "$warnreason"
+      if ! doWarn "$1" "$warnreason"; then
+        return 1
+      fi
     fi
     if [[ -n "$dosave" ]]; then
       doSaveWorld
@@ -908,6 +910,20 @@ doInstall() {
   runSteamCMDAppUpdate "$arkserverroot" validate
   # the current version should be the last version. We set our version
   getCurrentVersion
+}
+
+
+#
+# Cancels a pending shutdown
+#
+doCancelShutdown(){
+  if [ -f "${arkserverroot}/.ark-warn.lock" ]; then
+    local lockpid="$(<"${arkserverroot}/.ark-warn.lock")"
+    if [ -n "$lockpid" ]; then
+      kill "$lockpid"
+      rm -f "${arkserverroot}/.ark-warn.lock"
+    fi
+  fi
 }
 
 #
@@ -1028,11 +1044,27 @@ doWarn(){
   cd "$arkserverroot"
 
   (
+    echo "$$" >"${arkserverroot}/.ark-warn.lock.$$" 2>/dev/null
+    while true; do
+      if ! ln "${arkserverroot}/.ark-warn.lock.$$" "${arkserverroot}/.ark-warn.lock" 2>/dev/null; then
+        local lockpid="$(<"${arkserverroot}/.ark-warn.lock")"
+        if [ -n "$lockpid" ] && [ "$lockpid" != "$$" ] && kill -0 "$lockpid" 2>/dev/null; then
+          echo "Shutdown warning already in progress (PID: $lockpid)"
+          rm -f "${arkserverroot}/.ark-warn.lock.$$" 2>/dev/null
+          exit 1
+        fi
+        rm -f "${arkserverroot}/.ark-warn.lock"
+      else
+        break
+      fi
+    done
+    rm -f "${arkserverroot}/.ark-warn.lock.$$"
+
     update_cancelled(){
       if [ -n "$msgUpdateCancelled" ]; then
         msg="${msgUpdateCancelled//%s/$1}"
       else
-        msg="Update cancelled by operator ($1)"
+        msg="Shutdown cancelled by operator ($1)"
       fi
       doBroadcastWithEcho "${msg}"
     }
@@ -1056,6 +1088,7 @@ doWarn(){
       for warninterval in "${warnintervals[@]}"; do
         if [ "`getServerPID`" != "$pid" ]; then
           echo "Server has stopped.  Aborting $1"
+          rm -f "${arkserverroot}/.ark-warn.lock"
           return 1
         fi
         if (( warnminutes >= warninterval )); then
@@ -1067,6 +1100,7 @@ doWarn(){
             echo "There are ${numplayers} players connected"
             if (( (numplayers + 0) == 0 )); then
               doBroadcastWithEcho "Nobody is connected.  Shutting down immediately"
+              rm -f "${arkserverroot}/.ark-warn.lock"
               return 0
             fi
             wait $sleeppid
@@ -1086,6 +1120,7 @@ doWarn(){
         sleeppid=$!
         if [ "`getServerPID`" != "$pid" ]; then
           echo "Server has stopped.  Aborting update"
+          rm -f "${arkserverroot}/.ark-warn.lock"
           return 1
         fi
         printWarnMessage "$1" "$2" "seconds" "$warnseconds"
@@ -1094,6 +1129,7 @@ doWarn(){
           echo "There are ${numplayers} players connected"
           if (( (numplayers + 0) == 0 )); then
             doBroadcastWithEcho "Nobody is connected.  Shutting down immediately"
+            rm -f "${arkserverroot}/.ark-warn.lock"
             return 0
           fi
         fi
@@ -1101,6 +1137,8 @@ doWarn(){
         warnseconds=$warninterval
       done
     fi
+
+    rm -f "${arkserverroot}/.ark-warn.lock"
 
     if [ "`getServerPID`" != "$pid" ]; then
       echo "Server has stopped.  Aborting $1"
@@ -2203,6 +2241,9 @@ while true; do
       restart)
         doStop restart "${options[@]}"
         echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
+      ;;
+      cancelshutdown)
+        doCancelShutdown "${options[@]}"
       ;;
       install)
         doInstall

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -581,7 +581,7 @@ function numPlayersConnected(){
     my ($servername, $mapname, $game, $fullname, $rest) = split(/\x00/, substr($data, 6), 5);
     my $players = ord(substr($rest, 2, 1));
     print "$players\n";
-    ' "${ark_QueryPort}" "${ark_MultiHome:-127.0.0.1}"
+    ' "$(getQueryPort)" "${ark_MultiHome:-127.0.0.1}"
 }
 
 #
@@ -949,6 +949,7 @@ doWarn(){
         doBroadcastWithEcho "$warnmsg"
         for (( min = warnminutes - 1; min >= warninterval; min-- )); do
           numplayers=$(numPlayersConnected)
+          echo "There are ${numplayers} players connected"
           if (( (numplayers + 0) == 0 )); then
             echo "Nobody is connected.  Shutting down immediately"
             return 0
@@ -976,6 +977,7 @@ doWarn(){
       doBroadcastWithEcho "$warnmsg"
       if (( warnseconds >= 20 )); then
         numplayers=$(numPlayersConnected)
+        echo "There are ${numplayers} players connected"
         if (( (numplayers + 0) == 0 )); then
           echo "Nobody is connected.  Shutting down immediately"
           return 0

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -949,7 +949,7 @@ doWarn(){
         doBroadcastWithEcho "$warnmsg"
         for (( min = warnminutes - 1; min >= warninterval; min-- )); do
           numplayers=$(numPlayersConnected)
-          if (( numplayers + 0 == 0 )); then
+          if (( (numplayers + 0) == 0 )); then
             echo "Nobody is connected.  Shutting down immediately"
             return 0
           fi
@@ -976,7 +976,7 @@ doWarn(){
       doBroadcastWithEcho "$warnmsg"
       if (( warnseconds >= 20 )); then
         numplayers=$(numPlayersConnected)
-        if (( numplayers + 0 == 0 )); then
+        if (( (numplayers + 0) == 0 )); then
           echo "Nobody is connected.  Shutting down immediately"
           return 0
         fi
@@ -1114,7 +1114,7 @@ doUpdate() {
         fi
       elif [ "$updatetype" == "ifempty" ]; then
         numplayers=$(( $(numPlayersConnected) + 0 ))
-        if (( numplayers == 0 )); then
+        if (( numplayers != 0 )); then
           echo "${numplayers} players are still connected"
           return 1
         fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -602,6 +602,42 @@ doRun() {
 
   arkextraopts=( )
 
+  while read varname; do
+    val="${!varname}"
+    case "$varname" in
+      ark_*)
+        name="${varname#ark_}"
+
+        # Port is actually one higher than specified
+        # i.e. specifying port 7777 will have the server
+        # use port 7778
+        if [ "$name" == "Port" ]; then
+          (( val = val - 1 ))
+        fi
+
+        if [ -n "$val" ]; then
+          arkserveropts="${arkserveropts}?${name}=${val}"
+        else
+          arkserveropts="${arkserveropts}?${name}"
+        fi
+      ;;
+      arkopt_*)
+        name="${varname#arkopt_}"
+        val="${!varname}"
+
+        if [ -n "$val" ]; then
+          arkextraopts=( "${arkextraopts[@]}" "-${name}=${val}" )
+        fi
+      ;;
+      arkflag_*)
+        name="${varname#arkflag_}"
+
+        arkextraopts=( "${arkextraopts[@]}" "-${name}" )
+      ;;
+    esac
+    unset $varname
+  done < <(sed -n 's/^\(ark\(\|opt\|flag\)_[^= ]*\)=.*/\1/p' <"$configfile")
+
   # bring in ark_... options
   for varname in "${!ark_@}"; do
     name="${varname#ark_}"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1407,15 +1407,21 @@ doExtractMod(){
       { local $/; $data = <STDIN>; }
       my $mapnamelen = unpack("@0 L<", $data);
       my $mapname = substr($data, 4, $mapnamelen - 1);
-      my $mapfilelen = unpack("@" . ($mapnamelen + 8) . " L<", $data);
-      my $mapfile = substr($data, $mapnamelen + 12, $mapfilelen);
+      my $nummaps = unpack("@" . ($mapnamelen + 4) . " L<", $data);
+      my $pos = $mapnamelen + 8;
       my $modname = ($ARGV[1] || $mapname) . "\x00";
       my $modnamelen = length($modname);
       my $modpath = "../../../ShooterGame/Content/Mods/" . $ARGV[0] . "\x00";
       my $modpathlen = length($modpath);
-      print pack("L< L< L< Z$modnamelen L< Z$modpathlen L< L< Z$mapfilelen",
+      print pack("L< L< L< Z$modnamelen L< Z$modpathlen L<",
         $ARGV[0], 0, $modnamelen, $modname, $modpathlen, $modpath,
-	1, $mapfilelen, $mapfile);
+        $nummaps);
+      for (my $mapnum = 0; $mapnum < $nummaps; $mapnum++){
+        my $mapfilelen = unpack("@" . ($pos) . " L<", $data);
+        my $mapfile = substr($data, $mapnamelen + 12, $mapfilelen);
+        print pack("L< Z$mapfilelen", $mapfilelen, $mapfile);
+        $pos = $pos + 4 + $mapfilelen;
+      }
       print "\x33\xFF\x22\xFF\x02\x00\x00\x00\x01";
     ' $modid "$modname" <"$moddestdir/mod.info" >"${moddestdir}.mod"
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1350,7 +1350,9 @@ doExtractMod(){
 
     modname="$(curl -s "http://steamcommunity.com/sharedfiles/filedetails/?id=${modid}" | sed -n 's|^.*<div class="workshopItemTitle">\([^<]*\)</div>.*|\1|p')"
 
-    rm "${moddestdir}/.mod"
+    if [ -f "${moddestdir}/.mod" ]; then
+      rm "${moddestdir}/.mod"
+    fi
 
     perl -e '
       my $data;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1660,7 +1660,7 @@ doBackup(){
 
   saverootdir="${arkserverroot}/ShooterGame/Saved"
   savedcfgdir="${saverootdir}/Config/LinuxServer"
-  savedir="${savedrootdir}/${savedir}"
+  savedir="${saverootdir}/${savedir}"
 
   # Check for the (unlikely) case that the case of the
   # saved ark directory is screwed up

--- a/tools/systemd/arkmanager.init
+++ b/tools/systemd/arkmanager.init
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DAEMON=/usr/bin/arkmanager
+DAEMON="/usr/bin/arkmanager"
 
 for service in $(${DAEMON} list-instances --brief); do
   case "$1" in


### PR DESCRIPTION
**Modify `.mod` file creation (originally in #430):**

This brings the `.mod` file creation to be in line with the `<modid>.mod` files created by the ARK client.
For private mods where it can't fetch the mod name, it will use the name from the mod.info file.
For public mods, the `<modid>.mod` file created should match that created by the ARK client.

**Add Blob SHA to `--version` output (originally in #431)**

This should make it possible to determine the arkmanager version when it hasn't been installed using the netinstall script.

**Add support for adding and removing cron jobs (originally in #432)**

This has been asked a few times, including in #141 and #425

**Process ark options in config file order (originally in #433)**

This should add options to the ARK server command-line in the order they are specified in the config file.

**Use `serverMapModId` to set map name and `MapModID` option (originally in #438)**

It appears that putting the `-MapModID=<modid>` option in place of the map name no longer works.  Instead one must specify both the map name and the map mod ID.
This uses the `serverMapModId` setting to get the map name from the mod, and set the `MapModID` option to the mod id.
This should fix #437 and #436

**Return `-1` from `numplayers` if server unreachable (originally in #444)**
**Fix a couple of potential issues with player count checking**
**Fix `numPlayersConnected` to use `getQueryPort`**

These should fix #442

**Handle multiple map files in mods**

This should fix multi-map mods

**Account for all lower-case names in some environments**

This should fix #468 

**Parse output of `download_workshop_item` command**

This should fix possible instances where `steamcmd` puts the workshop files somewhere other than where we expect them.

**Improve broadcast warning messages**
**Allow stop and restart commands to take a reason**

These should satisfy #446 

**Move `.modbranch` to `__arkmanager_modbranch__.info`**

This should fix the reported problem in #471

**Remove now unnecessary ulimit setup**

Setting a ulimit above 1000 has not been necessary for a long time, and has never worked as a user.  Remove this unnecessary ulimit update.

**Fix an inconsistency between `install.sh` and `arkmanager.init`**

This should fix #479

**Fix a typo in doBackup**

Fixes 103c3ab - should fix #480

**Add `cancelshutdown` command**

This allows one to cancel a pending update, shutdown or restart that was run with the `--warn` option.  This was requested in #481