### PR TITLE
Default non-privileged instance-config path

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -368,7 +368,7 @@ Instance config files
 
 Instance config files are stored under
 `/etc/arkmanager/instances/<instancename>.cfg`,
-`~/.local/config/arkmanager/instances/<instancename>.cfg`
+`~/.config/arkmanager/instances/<instancename>.cfg`
 or as specified in the `configfile_<instancename>` options in
 the global config.
 


### PR DESCRIPTION
Default non-privileged instance-config path seems to have changed to ~/.config/