### PR TITLE
Release ARK Server Tools v1.6

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -230,15 +230,18 @@ instances.
     Installs all mods specified in the instance config into the
     `ShooterGame/Content/Mods` directory
 
-`installmod <modnum>`::
-    Installs the specified mod into the `ShooterGame/Content/Mods`
+`installmod <modnum>[,<modnum>[,...]]`::
+    Installs the specified mods into the `ShooterGame/Content/Mods`
     directory
 
-`uninstallmod <modnum>`::
-    Deletes the specified mod from the `ShooterGame/Content/Mods`
+`uninstallmod <modnum>[,<modnum>[,...]]`::
+    Deletes the specified mods from the `ShooterGame/Content/Mods`
     directory
 
-`reinstallmod <modnum>`::
+`removemod <modnum>[,<modnum>[,...]]`::
+    Deletes the specified mods from the SteamCMD workshop directory
+
+`reinstallmod <modnum>[,<modnum>[,...]]`::
     Runs the `uninstallmod` command followed by the `installmod`
     command
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -226,6 +226,10 @@ instances.
 `checkupdate`::
     Checks if an ARK server update is available
 
+`installmods`::
+    Installs all mods specified in the instance config into the
+    `ShooterGame/Content/Mods` directory
+
 `installmod <modnum>`::
     Installs the specified mod into the `ShooterGame/Content/Mods`
     directory

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -272,10 +272,16 @@ instances.
     `--hour=<hour>`;;
         Specifies one or more hours when the command should execute.
         This is the hour field of the cron job.
+	If you want to have the command execute every n hours, then
+	use `--hour='*/n'`
+	Default: `*` (i.e. all hours)
 
     `--minute=<minute>`;;
         Specifies one or more minutes of the hour when the command
         should execute.  This is the minute field of the cron job.
+	If you want to have the command execute every n minutes,
+	then use `--minute='*/n'`
+	Default: `0` (i.e. the first minute of the hour)
 
     `--enable-output`;;
         Enables the output from the command - the cron daemon usually

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -242,6 +242,22 @@ instances.
     Runs the `uninstallmod` command followed by the `installmod`
     command
 
+`enablemod <modnum>`::
+`enablemod <modnum>=<modtype>`::
+    Enables the `arkmod_<modnum>` setting in the instance config.
+    modtype defaults to `game`.
+    Mod types:
+
+    `game`;;
+        A mod in `GameModIds`
+
+    `map`;;
+        The `MapModId` mod
+
+    `tc`;;
+    `totalconversion`;;
+        The `TotalConversionMod` mod
+
 `backup`::
     Backs up the saved world and game config files to a compressed
     tar file in the backups directory specified in the config
@@ -494,6 +510,30 @@ the global config.
     `arkopt_StructureDestructionTag=DestroySwampSnowStructures` adds
     the `-StructureDestructionTag=DestroySwampSnowStructures`
     option.
+
+`arkmod_<modnum>=<modtype>`::
+    Specifies a mod that can be enabled or disabled using
+    `enablemod` and `disablemod`.  Note that mod ids specified
+    using these options are in addition to those specified directly
+    in the `ark_GameModIds` option, and override those specified in the
+    `ark_MapModId`, `serverMapMod` and `ark_TotalConversionMod`
+    options.  Options are processed in the order they are specified
+    in the instance config file, and `arkmod_*` options in the
+    common config file are not applied.
+    Mod types:
+
+    `game`;;
+        A mod to be specified in `GameModIds`
+
+    `map`;;
+        The mod to be specified in `MapModId`
+
+    `tc`;;
+    `totalconversion`;;
+        The mod to be specified in `TotalConversionMod`
+
+    `disabled`;;
+        A disabled mod
 
 Common ARK options
 ~~~~~~~~~~~~~~~~~~

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -262,6 +262,9 @@ instances.
     as well as the following options.  In order to specify an
     argument to the command (e.g. to the `broadcast` command),
     use the `--arg=<arg>` option.
+    Please read your `man 5 crontab` manpage to determine what
+    minute and hour values are valid, as some implementations
+    may not accept e.g. the `*/n` minute / hour specification.
 
     `--daily`;;
         The command should be executed daily

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -230,6 +230,9 @@ instances.
     Installs all mods specified in the instance config into the
     `ShooterGame/Content/Mods` directory
 
+`uninstallmods`::
+    Deletes all mods from the `ShooterGame/Content/Mods` directory
+
 `installmod <modnum>[,<modnum>[,...]]`::
     Installs the specified mods into the `ShooterGame/Content/Mods`
     directory

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -149,6 +149,11 @@ instances.
     `--noautoupdate`;;
         Disables automatic updating on startup if it is enabled
 
+    `--alwaysrestart`;;
+        Enable automatically restarting the server even if it crashes
+        without becoming ready for player connections.
+
+
 `stop`::
     Stops the server if it is running
 
@@ -342,6 +347,12 @@ The following options can be overridden on a per-instance basis:
 `arkautorestartfile`::
     The relative path within an ARK server install to place the
     autorestart lock file
+
+`arkAlwaysRestartOnCrash`::
+    Set to `true` to enable automatically restarting even when the
+    server has not become ready for player connections.
+    Be aware that this may cause the server to enter an endless
+    crash-restart loop if the cause of the crash is not resolved.
 
 `arkAutoUpdateOnStart`::
     Set to `true` to enable updating before server startup

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -396,6 +396,11 @@ The following options can be overridden on a per-instance basis:
 `arkMaxBackupSizeMB`::
     Limits the size of the stored backups
 
+`arkPriorityBoost`::
+    Attempts to boost the priority of the ARK server.
+    Negative values give a higher priority, and positive values give a lower priority.
+    Requires `sudo` and `renice`
+
 `msgWarnUpdateMinutes`::
 `msgWarnUpdateSeconds`::
 `msgWarnRestartMinutes`::

--- a/netinstall.sh
+++ b/netinstall.sh
@@ -28,11 +28,11 @@ fi
 
 function doInstallFromCommit(){
   local commit="$1"
-  tmpdir="$(mktemp -d "ark-server-tools-XXXXXXXX")"
+  tmpdir="$(mktemp -t -d "ark-server-tools-XXXXXXXX")"
   if [ -z "$tmpdir" ]; then echo "Unable to create temporary directory"; exit 1; fi
   cd "$tmpdir"
   echo "Downloading installer"
-  curl -L "https://github.com/${arkstGithubRepo}/archive/${commit}.tar.gz" | tar -xz
+  curl -s -L "https://github.com/${arkstGithubRepo}/archive/${commit}.tar.gz" | tar -xz
   cd "ark-server-tools-${commit}/tools"
   if [ ! -f "install.sh" ]; then echo "install.sh not found in $PWD"; exit 1; fi
   sed -i -e "s|^arkstCommit='.*'|arkstCommit='${commit}'|" \
@@ -45,9 +45,9 @@ function doInstallFromCommit(){
   rm -rf "$tmpdir"
 
   if [ "$result" = 0 ] || [ "$result" = 2 ]; then
-    "ARK Server Tools successfully installed"
+    echo "ARK Server Tools successfully installed"
   else
-    "ARK Server Tools install failed"
+    echo "ARK Server Tools install failed"
   fi
   return $result
 }
@@ -69,7 +69,7 @@ function doInstallFromRelease(){
     echo "Latest release is ${tagname}"
     echo "Getting commit for latest release..."
     local commit="$(curl -s "https://api.github.com/repos/${arkstGithubRepo}/git/refs/tags/${tagname}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p')"
-    doUpgradeToolsFromCommit "$commit"
+    doInstallFromCommit "$commit"
   else
     echo "Unable to get latest release"
     return 1

--- a/netinstall.sh
+++ b/netinstall.sh
@@ -4,6 +4,8 @@
 # Net Installer, used with curl
 #
 
+arkstGithubRepo="FezVrasta/ark-server-tools"
+
 steamcmd_user="$1"
 channel=${2:-master} # if defined by 2nd argument install the defined version, otherwise install master
 shift
@@ -30,7 +32,7 @@ function doInstallFromCommit(){
   if [ -z "$tmpdir" ]; then echo "Unable to create temporary directory"; exit 1; fi
   cd "$tmpdir"
   echo "Downloading installer"
-  curl -L "https://github.com/FezVrasta/ark-server-tools/archive/${commit}.tar.gz" | tar -xz
+  curl -L "https://github.com/${arkstGithubRepo}/archive/${commit}.tar.gz" | tar -xz
   cd "ark-server-tools-${commit}/tools"
   if [ ! -f "install.sh" ]; then echo "install.sh not found in $PWD"; exit 1; fi
   sed -i -e "s|^arkstCommit='.*'|arkstCommit='${commit}'|" \
@@ -61,12 +63,12 @@ function doInstallFromRelease(){
       tag_name) tagname="${v}"; ;;
       body) desc="${v}"
     esac
-  done < <(curl -s "https://api.github.com/repos/FezVrasta/ark-server-tools/releases/latest" | sed -n 's/^  "\([^"]*\)": "*\([^"]*\)"*,*/\1\t\2/p')
+  done < <(curl -s "https://api.github.com/repos/${arkstGithubRepo}/releases/latest" | sed -n 's/^  "\([^"]*\)": "*\([^"]*\)"*,*/\1\t\2/p')
 
   if [ -n "$tagname" ]; then
     echo "Latest release is ${tagname}"
     echo "Getting commit for latest release..."
-    local commit="$(curl -s "https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/tags/${tagname}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p')"
+    local commit="$(curl -s "https://api.github.com/repos/${arkstGithubRepo}/git/refs/tags/${tagname}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p')"
     doUpgradeToolsFromCommit "$commit"
   else
     echo "Unable to get latest release"
@@ -76,7 +78,7 @@ function doInstallFromRelease(){
 
 function doInstallFromBranch(){
   channel="$1"
-  commit="`curl -s "https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads/${channel}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`"
+  commit="`curl -s "https://api.github.com/repos/${arkstGithubRepo}/git/refs/heads/${channel}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`"
   
   if [ -z "$commit" ]; then
     if [ -n "$unstable" ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -57,10 +57,10 @@ doUpgradeToolsFromCommit(){
   rm -rf "$tmpdir"
 
   if [ "$result" = 0 ] || [ "$result" = 2 ]; then
-    "ARK Server Tools successfully upgraded"
+    echo "ARK Server Tools successfully upgraded"
     "$0" --version
   else
-    "ARK Server Tools upgrade failed"
+    echo "ARK Server Tools upgrade failed"
   fi
   exit $result
 }

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -2662,7 +2662,7 @@ main(){
         if [ -n "${arkstTag}" ]; then
           echo "Release Tag: ${arkstTag}"
         fi
-        blobsize="$(sed "s@^arkst\\(Commit\\|Tag\\)=.*@\\1=''@" "$0" | wc -c)"
+        blobsize="$(sed "s@^\\(arkst\\(Commit\\|Tag\\)\\)=.*@\\1=''@" "$0" | wc -c)"
         echo "Blob SHA: $( (echo -ne "blob ${blobsize}\0"; sed "s@^\\(arkst\\(Commit\\|Tag\\)\\)=.*@\\1=''@" "$0") | sha1sum | cut -d' ' -f1)"
         exit 1
       ;;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -44,7 +44,7 @@ doUpgradeToolsFromCommit(){
   if [ -z "$tmpdir" ]; then echo "Unable to create temporary directory"; exit 1; fi
   cd "$tmpdir"
   echo "Downloading installer"
-  curl -L "https://github.com/${arkstGithubRepo}/archive/${commit}.tar.gz" | tar -xz
+  curl -s -L "https://github.com/${arkstGithubRepo}/archive/${commit}.tar.gz" | tar -xz
   cd "ark-server-tools-${commit}/tools"
   if [ ! -f "install.sh" ]; then echo "install.sh not found in $PWD"; exit 1; fi
   sed -i -e "s|^arkstCommit='.*'|arkstCommit='${commit}'|" \

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -666,6 +666,12 @@ doRun() {
     fi
   fi
 
+  if [ " $* " = *" --wait "* ]; then
+    # This requires bash 4+
+    # $$ returns the main process, $BASHPID returns the current process
+    kill -STOP $BASHPID # wait for caller to renice us
+  fi
+
   arkserveropts="$serverMap"
 
   while read varname; do
@@ -893,7 +899,20 @@ doStart() {
     tput sc
     echo "The server is starting..."
 
-    doRun </dev/null >>"$logdir/$arkserverLog" 2>&1 & # output of this command is logged
+    local pid=$!
+    if [ -n "$arkPriorityBoost" ]; then
+      doRun --wait </dev/null >>"$logdir/$arkserverLog" 2>&1 & # output of this command is logged
+      local pid="$!"
+
+      # Wait for monitor process to suspend itself
+      wait
+
+      echo "Boosting priority of ark server"
+      sudo renice -n "$arkPriorityBoost" "$pid"
+      kill -CONT "$pid"
+    else
+      doRun </dev/null >>"$logdir/$arkserverLog" 2>&1 & # output of this command is logged
+    fi
     echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
     tput rc; tput ed;
     echo "The server is now running, and should be up within 10 minutes"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1284,6 +1284,7 @@ doUpdate() {
         fi
         rm -rf "$arkStagingDir/ShooterGame/Content/Mods/"*
         rm -rf "$arkStagingDir/ShooterGame/Saved/"*
+        rm -rf "$arkStagingDir/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps"
       fi
 
       if [ -z "$nodownload" ]; then
@@ -1384,7 +1385,7 @@ doUpdate() {
       echo "`timestamp`: update to $instver complete" >> "$logdir/update.log"
     fi
 
-    if [ -n "$modupdate" ]; then
+    if [ -n "$modupdate" ] && [ -z "$arkflag_automanagedmods" ]; then
       for modid in $(getModIds); do
         if isModUpdateNeeded $modid; then
           echo "Updating mod $modid"
@@ -1423,6 +1424,10 @@ getModIds(){
 #
 doDownloadMod(){
   local modid=$1
+  local steamcmdroot="$steamcmdroot"
+  if [ -n "$arkflag_automanagedmods" ]; then
+    steamcmdroot="$arkserverroot/Engine/Binaries/ThirdParty/SteamCMD/Linux"
+  fi
   local modsrcdir="$steamcmdroot/steamapps/workshop/content/$mod_appid/$modid"
   local moddldir="$steamcmdroot/steamapps/workshop/downloads/$mod_appid"
   cd "$steamcmdroot"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -745,6 +745,7 @@ doRun() {
     restartserver=0
     if [ -n "$arkAlwaysRestartOnCrash" ]; then
       restartserver=1
+      touch "$arkserverroot/$arkautorestartfile"
     fi
 
     sleep 5
@@ -782,6 +783,7 @@ doRun() {
     # doStop will remove the autorestart file
     if [ ! -f "$arkserverroot/$arkautorestartfile" ]; then
       restartserver=0
+
     fi
 
     if [ "$restartserver" -ne 0 ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -2088,6 +2088,23 @@ doListAllInstances(){
   fi
 }
 
+doPrintConfig(){
+  declare -A vars
+  declare -A vals
+  for v in $(eval echo \$\{\!{a..z}\*\} \$\{\!{A..Z}\*\} \$\{\!_\*\}); do
+    vals["$v"]="${!v}"
+  done
+  for cfgfile in "$configfile" "$HOME/.arkmanager.cfg" "/etc/arkmanager/arkmanager.cfg"; do
+    while read v; do
+      val="$(source "$cfgfile"; echo "${!v}")"
+      if [[ "$val" = "${vals[$v]}" && -z "${vars[$v]}" ]]; then
+        vars["$v"]="$cfgfile"
+	echo "${cfgfile} => ${v}"
+      fi
+    done < <(sed -n 's/^[[:space:]]*\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' <"$cfgfile")
+  done
+}
+
 useConfig() {
   configfile=
   if [ -f "/etc/arkmanager/instances/${1}.cfg" ]; then
@@ -2376,6 +2393,9 @@ main(){
         ;;
         rconcmd)
           rconcmd "${args[@]}"
+        ;;
+        printconfig)
+          doPrintConfig
         ;;
         status)
           printStatus

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -2002,7 +2002,7 @@ doInstallCronJob(){
         output=
       ;;
       --arg=*)
-        cmdargs="${cmdargs} $(printf "%q" "${opt#--opt=}")"
+        cmdargs="${cmdargs} $(printf "%q" "${opt#--arg=}")"
       ;;
       --*)
         cmdopts="${cmdopts} $(printf "%q" "${opt}")"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1228,7 +1228,7 @@ doUpdate() {
 
   cd "$arkserverroot"
 
-  if isUpdateNeeded; then
+  if [ -n "$appupdate" ] || isUpdateNeeded; then
     appupdate=1
 
     if [ -n "${arkStagingDir}" -a "${arkStagingDir}" != "${arkserverroot}" ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -513,6 +513,14 @@ function getServerPID(){
       return
     fi
   fi
+  if [ -f "${arkserverroot}/${arkserveroldpidfile}" ]; then
+    serverpid="$(<"${arkserverroot}/${arkserveroldpidfile}")"
+    if kill -0 "$serverpid" >/dev/null 2>&1; then
+      echo $serverpid
+      return
+    fi
+  fi
+
   if [ -z "$arkopt_clusterid" ]; then
     ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'
   fi
@@ -995,6 +1003,10 @@ doStop() {
         kill $PID
       fi
     fi
+
+    rm -f "${arkserverroot}/${arkserverpidfile}"
+    rm -f "${arkserverroot}/${arkserveroldpidfile}"
+    rm -f "${arkserverroot}/${arkmanagerpidfile}"
 
     tput rc; tput ed;
     echo "The server has been stopped"
@@ -2375,6 +2387,7 @@ useConfig() {
   fi
   arkautorestartfile="${arkautorestartfile:-ShooterGame/Saved/.autorestart-${1}}"
   arkserverpidfile="${arkserverpidfile:-ShooterGame/Saved/.arkserver-${1}.pid}"
+  arkserveroldpidfile="ShooterGame/Saved/.arkserver.pid"
   arkmanagerpidfile="${arkmanagerpidfile:-ShooterGame/Saved/.arkmanager-${1}.pid}"
 }
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -616,7 +616,17 @@ function numPlayersConnected(){
       }
       ord(substr($data, 4, 1)) != 0x44 and (print "-1" and exit(1));
       my $players = ord(substr($data, 5, 1));
-      print "$players\n";
+      my $active = 0;
+      my $pdata = substr($data, 6);
+      for my $i (0 .. $players) {
+        my $idx = ord(substr($pdata, 0, 1));
+        my ($name, $rest) = split(/\x00/, substr($pdata, 1), 2);
+        $pdata = substr($rest, 8);
+        if ($name != "") {
+          $active = $active + 1;
+        }
+      }
+      print "$active\n";
       ' "$(getQueryPort)" "${ark_MultiHome:-127.0.0.1}"
   else
     perl -MSocket -e '
@@ -2114,7 +2124,17 @@ printStatus(){
       }
       ord(substr($data, 4, 1)) != 0x44 and (print ("A2S_PLAYERS Response: : " . unpack("H*", $data)) and exit(1));
       my $players = ord(substr($data, 5, 1));
-      print "Active Players: $players\n";
+      my $active = 0;
+      my $pdata = substr($data, 6);
+      for my $i (0 .. $players) {
+        my $idx = ord(substr($pdata, 0, 1));
+        my ($name, $rest) = split(/\x00/, substr($pdata, 1), 2);
+        $pdata = substr($rest, 8);
+        if ($name != "") {
+          $active = $active + 1;
+        }
+      }
+      print "Active Players: $active\n";
       ' "$(getQueryPort)" "${ark_MultiHome:-127.0.0.1}"
 
     if isTheServerOnline; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1884,14 +1884,29 @@ doInstallAllMods(){
 }
 
 #
+# Removes all mods from the mods directory
+#
+doUninstallAllMods(){
+  for modid in $(getModIds); do
+    if [[ "$modid" != "111111111" && "$modid" != "TheCenter" ]]; then
+      doUninstallMod "$modid"
+    fi
+  done
+}
+
+#
 # Removes mod from mods directory
 #
 doUninstallMod(){
   local modid
   for modid in "${1//,/ }"; do
     local moddir="$arkserverroot/ShooterGame/Content/Mods/$modid"
+    local modfile="$arkserverroot/ShooterGame/Content/Mods/${modid}.mod"
     if [ -d "${moddir}" ]; then
       rm -rf "${moddir}"
+    fi
+    if [ -f "${modfile}" ]; then
+      rm -f "$modfile"
     fi
   done
 }
@@ -2599,6 +2614,9 @@ main(){
         installmods)
           doInstallAllMods
         ;;
+	uninstallmods)
+	  doUninstallAllMods
+	;;
         uninstallmod)
           doUninstallMod "${args[@]}"
         ;;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -2017,7 +2017,7 @@ doInstallCronJob(){
   cronjob="${minute} ${hour} * * * ${arkmanagerpath} --cronjob ${command} @${instance} ${cmdopts} --args ${cmdargs} -- ${output}"
 
   (crontab -l | \
-    sed -e "/ [*] [*] [*] ${arkmanagerpath} --cronjob ${command} @${instance} /d";
+    sed -e "\\# [*] [*] [*] ${arkmanagerpath} --cronjob ${command} @${instance} #d";
     echo "${cronjob}" ) | \
     crontab -
 }
@@ -2030,7 +2030,7 @@ doRemoveCronJob(){
   command="$1"
 
   crontab -l | \
-    sed -e "/ [*] [*] [*] ${arkmanagerpath} --cronjob ${command} @${instance} /d" | \
+    sed -e "\\# [*] [*] [*] ${arkmanagerpath} --cronjob ${command} @${instance} #d" | \
     crontab -
 }
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -886,7 +886,7 @@ doStop() {
     for arg in "$@"; do
       case "$arg" in
         --warn) dowarn=1; ;;
-        --warnreason=*) warnreason="${arg#--warnreason=}"; ;;
+        --warnreason=*) warnreason="${arg#--warnreason=}"; dowarn=1; ;;
         --saveworld) dosave=1; ;;
       esac
     done
@@ -1280,7 +1280,7 @@ doUpdate() {
       --safe) updatetype=safe; ;;
       --warn) updatetype=warn; ;;
       --ifempty) updatetype=ifempty; ;;
-      --warnreason=*) warnreason="${arg#--warnreason=}"; ;;
+      --warnreason=*) warnreason="${arg#--warnreason=}"; updatetype=warn; ;;
       --validate) validate=validate; appupdate=1; ;;
       --saveworld) saveworld=1; ;;
       --update-mods) modupdate=1; ;;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -991,7 +991,6 @@ printWarnMessage(){
     reason="${reason//\{time\}/${msgtime}}"
     reason="${reason//\{modnamesupdated\}/${modnamesupdated}}"
     msg="${msg//\{reason\}/${reason}}"
-    printf "%s\n" "$msg"
   else
     if [ "$1" == "update" ]; then
       if [ "$3" == "minutes" ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -151,6 +151,8 @@ arkserverLog="arkserver.log"    # here is logged the output of ShooterGameServer
 appid="${appid:-376030}"
 mod_appid="${mod_appid:-346110}"
 arkautorestartfile="${arkautorestartfile:-ShooterGame/Saved/.autorestart}"
+arkserverpidfile="${arkserverpidfile:-ShooterGame/Saved/.arkserver.pid}"
+arkmanagerpidfile="${arkmanagerpidfile:-ShooterGame/Saved/.arkmanager.pid}"
 install_bindir="${install_bindir:-${0%/*}}"
 install_libexecdir="${install_libexecdir:-${install_bindir%/*}/libexec/arkmanager}"
 
@@ -507,6 +509,13 @@ function getAvailableVersion(){
 # Get the PID of the server process
 #
 function getServerPID(){
+  if [ -f "${arkserverroot}/${arkserverpidfile}" ]; then
+    serverpid="$(<"${arkserverroot}/${arkserverpidfile}")"
+    if kill -0 "$serverpid" >/dev/null 2>&1; then
+      echo $serverpid
+      return
+    fi
+  fi
   ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'
 }
 
@@ -609,6 +618,14 @@ function numPlayersConnected(){
 #
 doRun() {
   cd "${arkserverroot}/${arkserverexec%/*}"
+
+  if isTheServerRunning; then
+    echo "Error: another server instance is running from the same directory"
+    echo "Aborting - two servers MUST NOT run from the same directory"
+    exit 1
+  fi
+  
+  echo "$$" >"${arkserverroot}/${arkmanagerpidfile}"
 
   arkserveropts="$serverMap"
 
@@ -722,10 +739,11 @@ doRun() {
   # Shutdown the server when we are terminated
   shutdown_server(){
     restartserver=0
-    rm "$arkserverroot/$arkautorestartfile"
+    rm -f "$arkserverroot/$arkautorestartfile"
     if [ "$serverpid" -ne 0 ]; then
-      kill -INT $serverpid
+      kill -INT $serverpid >/dev/null 2>&1
     fi
+    exit 0
   }
 
   trap shutdown_server INT TERM
@@ -739,6 +757,7 @@ doRun() {
     "$arkserverroot/$arkserverexec" "$arkserveropts" "${arkextraopts[@]}" &
     # Grab the server PID
     serverpid=$!
+    echo "$serverpid" >"${arkserverroot}/${arkserverpidfile}"
     echo "`timestamp`: Server PID: $serverpid"
     # Disable auto-restart so we don't get caught in a restart loop
     rm -f "$arkserverroot/$arkautorestartfile"
@@ -767,8 +786,6 @@ doRun() {
         echo "`timestamp`: Bad PID '$pid'; expected '$serverpid'"
         if [ "$pid" != "" ]; then
 	  # Another instance must be running - disable autorestart
-	  echo "Error: another server instance is running from the same directory"
-	  echo "Aborting - two servers MUST NOT run from the same directory"
 	  restartserver=0
 	fi
 	break
@@ -880,6 +897,13 @@ doStop() {
       tput rc
       echo "Killing server..."
       kill -KILL $PID
+    fi
+
+    if [ -f "${arkserverroot}/${arkmanagerpidfile}" ]; then
+      PID="$(<"${arkserverroot}/${arkmanagerpidfile}")"
+      if [ -n "$PID" ]; then
+        kill $PID
+      fi
     fi
 
     tput rc; tput ed;

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1803,6 +1803,15 @@ doInstallMod(){
 }
 
 #
+# Downloads and installs all requested mods
+#
+doInstallAllMods(){
+  for modid in $(getModids); do
+    doInstallMod "$modid"
+  done
+}
+
+#
 # Removes mod from mods directory
 #
 doUninstallMod(){
@@ -2475,6 +2484,9 @@ main(){
         ;;
         installmod)
           doInstallMod "${args[@]}"
+        ;;
+        installmods)
+          doInstallAllMods
         ;;
         uninstallmod)
           doUninstallMod "${args[@]}"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1861,16 +1861,17 @@ doExtractMod(){
 # Downloads mod and installs it into mods directory
 #
 doInstallMod(){
-  local modid=$1
+  local modid
+  for modid in "${1//,/ }"; do
+    if [ -f "$steamcmdroot/steamapps/workshop/appworkshop_${mod_appid}.acf" ]; then
+      sed -i "/^\\t\\t\"${modid}\"/,/^\\t\\t}/d" "$steamcmdroot/steamapps/workshop/appworkshop_${mod_appid}.acf"
+    fi
 
-  if [ -f "$steamcmdroot/steamapps/workshop/appworkshop_${mod_appid}.acf" ]; then
-    sed -i "/^\\t\\t\"${modid}\"/,/^\\t\\t}/d" "$steamcmdroot/steamapps/workshop/appworkshop_${mod_appid}.acf"
-  fi
-
-  if doDownloadMod $modid; then
-    doExtractMod $modid
-    echo "Mod $modid installed"
-  fi
+    if doDownloadMod $modid; then
+      doExtractMod $modid
+      echo "Mod $modid installed"
+    fi
+  done
 }
 
 #
@@ -1886,11 +1887,13 @@ doInstallAllMods(){
 # Removes mod from mods directory
 #
 doUninstallMod(){
-  local modid=$1
-  local moddir="$arkserverroot/ShooterGame/Content/Mods/$modid"
-  if [ -d "${moddir}" ]; then
-    rm -rf "${moddir}"
-  fi
+  local modid
+  for modid in "${1//,/ }"; do
+    local moddir="$arkserverroot/ShooterGame/Content/Mods/$modid"
+    if [ -d "${moddir}" ]; then
+      rm -rf "${moddir}"
+    fi
+  done
 }
 
 #

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -513,7 +513,9 @@ function getServerPID(){
       return
     fi
   fi
-  ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'
+  if [ -z "$arkopt_clusterid" ]; then
+    ps -ef | grep "$arkserverroot/$arkserverexec" | grep -v grep | awk '{print $2}'
+  fi
 }
 
 #

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -622,7 +622,7 @@ function numPlayersConnected(){
         my $idx = ord(substr($pdata, 0, 1));
         my ($name, $rest) = split(/\x00/, substr($pdata, 1), 2);
         $pdata = substr($rest, 8);
-        if ($name != "") {
+        if ($name ne "") {
           $active = $active + 1;
         }
       }
@@ -2130,7 +2130,7 @@ printStatus(){
         my $idx = ord(substr($pdata, 0, 1));
         my ($name, $rest) = split(/\x00/, substr($pdata, 1), 2);
         $pdata = substr($rest, 8);
-        if ($name != "") {
+        if ($name ne "") {
           $active = $active + 1;
         }
       }

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -7,7 +7,8 @@
 # Contributors:         Sispheor, Atriusftw, klightspeed, lexat, puseidr
 
 # Script version
-arkstVersion='1.6'
+arkstVersion='1.6-pre1'
+arkstTag=''
 arkstCommit=''
 
 doUpgradeTools() {
@@ -15,9 +16,57 @@ doUpgradeTools() {
   if [ "$UID" == 0 -o "$steamcmd_user" == "--me" ]; then
     sudo=
   fi
+
+  local reinstall_args=()
+  if [ -n "$install_bindir" ]; then
+    reinstall_args=( "${reinstall_args[@]}" "--bindir" "$install_bindir" )
+  fi
+  if [ -n "$install_libexecdir" ]; then
+    reinstall_args=( "${reinstall_args[@]}" "--libexecdir" "$install_libexecdir" )
+  fi
+  if [ -n "$install_datadir" ]; then
+    reinstall_args=( "${reinstall_args[@]}" "--datadir" "$install_datadir" )
+  fi
+
   echo "arkmanager v${arkstVersion}: Checking for updates..."
-  arkstLatestVersion=`curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/.version`
-  arkstLatestCommit=`curl -s https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads/${arkstChannel} | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`
+
+  if [ -n "$arkstUnstable" ] || [ "$arkstChannel" != "master" ]; then
+    doUpgradeToolsFromBranch
+  else
+    doUpgradeToolsFromRelease
+  fi
+}
+
+doUpgradeToolsFromCommit(){
+  local commit="$1"
+  tmpdir="$(mktemp -d "ark-server-tools-XXXXXXXX")"
+  if [ -z "$tmpdir" ]; then echo "Unable to create temporary directory"; exit 1; fi
+  cd "$tmpdir"
+  echo "Downloading installer"
+  curl -L "https://github.com/FezVrasta/ark-server-tools/archive/${commit}.tar.gz" | tar -xz
+  cd "ark-server-tools-${commit}/tools"
+  if [ ! -f "install.sh" ]; then echo "install.sh not found in $PWD"; exit 1; fi
+  sed -i -e "s|^arkstCommit='.*'|arkstCommit='${commit}'|" \
+         -e "s|^arkstTag='.*'|arkstTag='${tagname}'|" \
+         arkmanager
+  echo "Running install.sh"
+  bash install.sh "$steamcmd_user" "${reinstall_args[@]}"
+  result=$?
+  cd /
+  rm -rf "$tmpdir"
+
+  if [ "$result" = 0 ] || [ "$result" = 2 ]; then
+    "ARK Server Tools successfully upgraded"
+    "$0" --version
+  else
+    "ARK Server Tools upgrade failed"
+  fi
+  exit $result
+}
+
+doUpgradeToolsFromBranch(){
+  arkstLatestVersion=`curl -s "https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/.version"`
+  arkstLatestCommit=`curl -s "https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads/${arkstChannel}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`
 
   if [ "$arkstLatestVersion" == "Not Found" ]; then
     echo "Channel ${arkstChannel} does not exist"
@@ -28,32 +77,52 @@ doUpgradeTools() {
     return
   fi
 
-  reinstall_args=()
-  if [ -n "$install_bindir" ]; then
-    reinstall_args=( "${reinstall_args[@]}" "--bindir" "$install_bindir" )
-  fi
-  if [ -n "$install_libexecdir" ]; then
-    reinstall_args=( "${reinstall_args[@]}" "--libexecdir" "$install_libexecdir" )
-  fi
-  if [ -n "$install_datadir" ]; then
-    reinstall_args=( "${reinstall_args[@]}" "--datadir" "$install_datadir" )
-  fi
+  REPLY=
+
   if [[ $arkstLatestVersion > $arkstVersion ]]; then
     read -p "A new version was found! Do you want to upgrade ARK Server Tools to v${arkstLatestVersion}?" -n 1 -r
-    echo -en "\n"
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s -- ${steamcmd_user} ${arkstChannel} "${reinstall_args[@]}"
-        exit 0
-    fi
+    echo
   elif [[ $arkstLatestVersion == $arkstVersion && "$arkstLatestCommit" != "$arkstCommit" ]]; then
     read -p "A hotfix is available for v${arkstLatestVersion}.  Do you wish to install it?" -n 1 -r
-    echo -en "\n"
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        curl -s https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/netinstall.sh | $sudo bash -s -- ${steamcmd_user} ${arkstChannel} "${reinstall_args[@]}"
-        exit 0
-    fi
+    echo
   else
     echo "Your ARK server tools are already up to date"
+  fi
+
+  if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+    doUpgradeToolsFromCommit "$arkstLatestCommit"
+  fi
+}
+
+doUpgradeToolsFromRelease(){
+  local tagname=
+  local desc=
+
+  echo "Getting latest release..."
+  # Read the variables from github
+  while IFS=$'\t' read n v; do
+    case "${n}" in
+      tag_name) tagname="${v}"; ;;
+      body) desc="${v}"
+    esac
+  done < <(curl -s "https://api.github.com/repos/FezVrasta/ark-server-tools/releases/latest" | sed -n 's/^  "\([^"]*\)": "*\([^"]*\)"*,*/\1\t\2/p')
+
+  if [ -n "$tagname" ]; then
+    if [ "$tagname" != "$arkstTag" ]; then
+      echo "A new version has been released: ${tagname}"
+      echo -e "$desc"
+      read -p "Do you want to upgrade to ${tagname}? [Y/N] " -n 1 -r
+      echo
+      if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+        echo "Getting commit for latest release..."
+        local commit="$(curl -s "https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/tags/${tagname}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p')"
+        doUpgradeToolsFromCommit "$commit"
+      fi
+    else
+      echo "Your ARK server tools are already up to date"
+    fi
+  else
+    echo "Unable to get latest release"
   fi
 }
 
@@ -86,7 +155,10 @@ runAsRoot(){
     fi
   }
 
+  cd /
+
   arkstChannel="$(getConfigVar arkstChannel "master")"
+  arkstUnstable="$(getConfigVar arkstUnstable "")"
   install_bindir="$(getConfigVar install_bindir "${0%/*}")"
   install_libexecdir="$(getConfigVar install_libexecdir "${install_bindir%/*}/libexec/arkmanager")"
   install_datadir="$(getConfigVar install_datadir "${install_bindir%/*}/share/arkmanager")"
@@ -2565,8 +2637,11 @@ main(){
         if [ -n "${arkstCommit}" ]; then
           echo "Commit: ${arkstCommit:0:7}"
         fi
-        blobsize="$(sed "s@^arkstCommit=.*@arkstCommit=''@" "$0" | wc -c)"
-        echo "Blob SHA: $( (echo -ne "blob ${blobsize}\0"; sed "s@^arkstCommit=.*@arkstCommit=''@" "$0") | sha1sum | cut -d' ' -f1)"
+        if [ -n "${arkstTag}" ]; then
+          echo "Release Tag: ${arkstTag}"
+        fi
+        blobsize="$(sed "s@^arkst\\(Commit\\|Tag\\)=.*@\\1=''@" "$0" | wc -c)"
+        echo "Blob SHA: $( (echo -ne "blob ${blobsize}\0"; sed "s@^arkst\\(Commit\\|Tag\\)=.*@\\1=''@" "$0") | sha1sum | cut -d' ' -f1)"
         exit 1
       ;;
       -h|--help)

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1041,6 +1041,28 @@ printWarnMessage(){
 }
 
 #
+# Checks if a player has requested an update cancel in the last 5 minutes
+#
+isUpdateCancelRequested(){
+  if [ -n "$chatCommandRestartCancel" ]; then
+    local canceltime="$(
+      find ~/ARK/server1/ShooterGame/Saved/Logs -name 'ServerGame.*.log' -mmin -5 -print0 | 
+        xargs -0 grep -F -e "${chatCommandRestartCancel}" | 
+        sed 's@^[[]\(....\)\.\(..\)\.\(..\)-\(..\)\.\(..\)\.\(..\):.*@\1-\2-\3 \4:\5:\6 UTC@' | 
+        head -n1)"
+    if [ -n canceltime ]; then
+      canceltime="$(date +%s --date="${canceltime}")"
+      local timenow="$(date +%s --date="now - 5 minutes")"
+      if (( canceltime > timenow )); then
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
+}
+
+#
 # Waits for a configurable number of minutes before updating the server
 #
 doWarn(){
@@ -1107,6 +1129,10 @@ doWarn(){
               rm -f "${arkserverroot}/.ark-warn.lock"
               return 0
             fi
+            if isUpdateCancelRequested; then
+              doBroadcastWithEcho "Restart cancelled by player request"
+              return 1
+            fi
             wait $sleeppid
             if (( $min > $warninterval )); then
               sleep 1m &
@@ -1135,6 +1161,10 @@ doWarn(){
             doBroadcastWithEcho "Nobody is connected.  Shutting down immediately"
             rm -f "${arkserverroot}/.ark-warn.lock"
             return 0
+          fi
+          if isUpdateCancelRequested; then
+            doBroadcastWithEcho "Restart cancelled by player request"
+            return 1
           fi
         fi
         wait $sleeppid

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1982,6 +1982,7 @@ doInstallCronJob(){
   cmdopts="${arkCronExtraOpts}"
   cmdargs=""
   output=">/dev/null 2>&1"
+  arkmanagerpath="${0}"
   command="$1"
   shift
 
@@ -2013,10 +2014,10 @@ doInstallCronJob(){
     esac
   done
 
-  cronjob="${minute} ${hour} * * * arkmanager --cronjob ${command} @${instance} ${cmdopts} --args ${cmdargs} -- ${output}"
+  cronjob="${minute} ${hour} * * * ${arkmanagerpath} --cronjob ${command} @${instance} ${cmdopts} --args ${cmdargs} -- ${output}"
 
   (crontab -l | \
-    sed -e "/ [*] [*] [*] arkmanager --cronjob ${command} @${instance} /d";
+    sed -e "/ [*] [*] [*] ${arkmanagerpath} --cronjob ${command} @${instance} /d";
     echo "${cronjob}" ) | \
     crontab -
 }
@@ -2025,10 +2026,11 @@ doInstallCronJob(){
 # Removes an installed cron job
 #
 doRemoveCronJob(){
+  arkmanagerpath="${0}"
   command="$1"
 
   crontab -l | \
-    sed -e "/ [*] [*] [*] arkmanager --cronjob ${command} @${instance} /d" | \
+    sed -e "/ [*] [*] [*] ${arkmanagerpath} --cronjob ${command} @${instance} /d" | \
     crontab -
 }
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1806,7 +1806,7 @@ doInstallMod(){
 # Downloads and installs all requested mods
 #
 doInstallAllMods(){
-  for modid in $(getModids); do
+  for modid in $(getModIds); do
     doInstallMod "$modid"
   done
 }

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1061,6 +1061,7 @@ printWarnMessage(){
     fi
     reason="${reason//\{time\}/${msgtime}}"
     reason="${reason//\{modnamesupdated\}/${modnamesupdated}}"
+    reason="${reason//\{version\}/${arkversion}}"
     msg="${msg//\{reason\}/${reason}}"
   else
     if [ "$1" == "update" ]; then
@@ -1337,6 +1338,7 @@ doUpdate() {
           cp -al "$arkserverroot/linux64/." "$arkStagingDir/linux64"
           cp -al "$arkserverroot/PackageInfo.bin" "$arkStagingDir/PackageInfo.bin"
           cp -al "$arkserverroot/steamclient.so" "$arkStagingDir/steamclient.so"
+          cp -al "$arkserverroot/version.txt" "$arkStagingDir/version.txt"
           cp -a "$arkserverroot/steamapps/." "$arkStagingDir/steamapps"
         else
           rsync -a "$arkserverroot/." "$arkStagingDir/."
@@ -1370,6 +1372,7 @@ doUpdate() {
     fi
     echo "Not applying update - download-only enabled"
   elif [ -n "$appupdate" -o -n "$modupdate" ]; then
+    arkversion="$(<"$arkserverroot/version.txt")"
     if isTheServerRunning; then
       if [ "$updatetype" == "safe" ]; then
         while [ ! `find $arkserverroot/ShooterGame/Saved/SavedArks -mmin -1 -name ${serverMap##*/}.ark` ]; do
@@ -1418,6 +1421,7 @@ doUpdate() {
           cp -alu --remove-destination "$arkStagingDir/linux64/." "$arkserverroot/linux64"
           cp -alu --remove-destination "$arkStagingDir/PackageInfo.bin" "$arkserverroot/PackageInfo.bin"
           cp -alu --remove-destination "$arkStagingDir/steamclient.so" "$arkserverroot/steamclient.so"
+          cp -alu --remove-destination "$arkStagingDir/version.txt" "$arkserverroot/version.txt"
           cp -au --remove-destination "$arkStagingDir/steamapps/." "$arkserverroot/steamapps"
         else
           rsync -a "$arkStagingDir/." "$arkserverroot"
@@ -2107,7 +2111,8 @@ printStatus(){
   fi
 
   getCurrentVersion
-  echo -e "$NORMAL" "Server version: " "$GREEN" $instver "$NORMAL"
+  echo -e "$NORMAL" "Server build ID: " "$GREEN" $instver "$NORMAL"
+  echo -e "$NORMAL" "Server version: " "$GREEN" "$(<"$arkserverroot/version.txt")" "$NORMAL"
 }
 
 getAllInstanceNames(){

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1844,6 +1844,37 @@ doUninstallMod(){
 }
 
 #
+# Enables a mod in the config
+#
+doEnableMod(){
+  local modid="${1%=*}"
+  local modtype="${1#*=}"
+  if [ "$modtype" = "$1" ]; then
+    modtype=game
+  fi
+  local modvar="arkmod_${modid}"
+  if [ -n "${!modvar}" ]; then
+    sed -i "s|^\(${modvar}\)=[^ ]*|\1=${modtype}|" "$configfile"
+  else
+    echo "${modvar}=${modtype}" >>"$configfile"
+  fi
+}
+
+#
+# Disable a mod in the config
+#
+doDisableMod(){
+  local modid="$1"
+  local modvar="arkmod_$modid"
+  if [ "$ark_GameModIds" = *"$modid"* ]; then
+    sed -i "s|^\(ark_GameModIds=\(\|[\"']\)\(\|[^\"' ]*,\)\)${modid},*|\1|" "$configfile"
+  fi
+  if [ -n "$modvar" ]; then
+    sed -i "s|^\(arkmod_${modid}\)=[^ ]*|\1=disabled|" "$configfile"
+  fi
+}
+
+#
 # Removes mod from steamcmd workshop directory
 #
 doRemoveMods(){
@@ -2505,6 +2536,12 @@ main(){
         ;;
         installmod)
           doInstallMod "${args[@]}"
+        ;;
+        enablemod)
+          doEnableMod "${args[@]}"
+        ;;
+        disablemod)
+          doDisableMod "${args[@]}"
         ;;
         installmods)
           doInstallAllMods

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1174,7 +1174,10 @@ doWarn(){
           for (( min = warnminutes; min >= warninterval; min-- )); do
             numplayers=$(numPlayersConnected)
             echo "There are ${numplayers} players connected"
-            if (( (numplayers + 0) == 0 )); then
+            if [[ "numplayers" == "-1" ]]; then
+              echo "Server is not running.  Shutting down immediately"
+              return 0
+            elif (( (numplayers + 0) == 0 )); then
               doBroadcastWithEcho "Nobody is connected.  Shutting down immediately"
               rm -f "${arkserverroot}/.ark-warn.lock"
               return 0
@@ -1207,7 +1210,10 @@ doWarn(){
         if (( warnseconds >= 20 )); then
           numplayers=$(numPlayersConnected)
           echo "There are ${numplayers} players connected"
-          if (( (numplayers + 0) == 0 )); then
+          if [[ "numplayers" == "-1" ]]; then
+            echo "Server is not running.  Shutting down immediately"
+            return 0
+          elif (( (numplayers + 0) == 0 )); then
             doBroadcastWithEcho "Nobody is connected.  Shutting down immediately"
             rm -f "${arkserverroot}/.ark-warn.lock"
             return 0

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1252,8 +1252,11 @@ doUpdate() {
       if [ -z "$nodownload" ]; then
         echo -n "Downloading ARK update"
         cd "$steamcmdroot"
-        runSteamCMDAppUpdate "$arkStagingDir" $validate
-        if [ -d "${arkStagingDir}/steamapps/downloading/${appid}" ]; then
+        if runSteamCMDAppUpdate "$arkStagingDir" $validate; then
+	  rm -rf "${arkStagingDir}/steamapps/downloading/${appid}"
+	fi
+
+	if [ -d "${arkStagingDir}/steamapps/downloading/${appid}" ]; then
           echo "Update download interrupted"
           return 1
         fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -172,7 +172,7 @@ declare -A modsrcdirs
 # timestamp
 #
 timestamp() {
-  date +%T
+  date +"%Y-%m-%d %H:%M:%S"
 }
 
 #

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1185,7 +1185,7 @@ doUpdate() {
       modupdate=1
     elif [ "$arg" == "--backup" ]; then
       arkBackupPreUpdate=true
-    elif [[ "$arg" =~ "^--stagingdir=" ]]; then
+    elif [[ "$arg" =~ ^--stagingdir= ]]; then
       arkStagingDir="${ark#--stagingdir=}"
     elif [ "$arg" == "--downloadonly" ]; then
       downloadonly=1

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -865,7 +865,7 @@ doStop() {
     for arg in "$@"; do
       case "$arg" in
         --warn) dowarn=1; ;;
-        --warnreason=*) warnreason="${arg#*=}"; ;;
+        --warnreason=*) warnreason="${arg#--warnreason=}"; ;;
         --saveworld) dosave=1; ;;
       esac
     done
@@ -995,6 +995,12 @@ printWarnMessage(){
       fi
     fi
     msg="${msgWarnReason//\{time\}/$msgtime}"
+    if [ -n "$warnreason" ]; then
+      local v="warnreason_$warnreason"
+      reason="${!v}"
+      if [ -z "$reason" ]; then
+        reason="$warnreason"
+      fi
     if [ "$1" == "update" ]; then
       if [ -n "$appupdate" ]; then
         if [ -n "$modupdate" ]; then
@@ -1242,34 +1248,24 @@ doUpdate() {
   local nodownload=
 
   for arg in "$@"; do
-    if [ "$arg" == "--force" ]; then
-      appupdate=1
-    elif [ "$arg" == "--safe" ]; then
-      updatetype=safe
-    elif [ "$arg" == "--warn" ]; then
-      updatetype=warn
-    elif [ "$arg" == "--ifempty" ]; then
-      updatetype=ifempty
-    elif [ "$arg" == "--validate" ]; then
-      validate=validate
-      appupdate=1
-    elif [ "$arg" == "--saveworld" ]; then
-      saveworld=1
-    elif [ "$arg" == "--update-mods" ]; then
-      modupdate=1
-    elif [ "$arg" == "--backup" ]; then
-      arkBackupPreUpdate=true
-    elif [[ "$arg" =~ ^--stagingdir= ]]; then
-      arkStagingDir="${ark#--stagingdir=}"
-    elif [ "$arg" == "--downloadonly" ]; then
-      downloadonly=1
-    elif [ "$arg" == "--no-download" ]; then
-      nodownload=1
-    else
-      echo "Unrecognized option $arg"
-      echo "Try 'arkmanager -h' or 'arkmanager --help' for more information."
-      exit 1
-    fi
+    case "$arg" in
+      --force) appupdate=1; ;;
+      --safe) updatetype=safe; ;;
+      --warn) updatetype=warn; ;;
+      --ifempty) updatetype=ifempty; ;;
+      --warnreason=*) warnreason="${arg#--warnreason=}"; ;;
+      --validate) validate=validate; appupdate=1; ;;
+      --saveworld) saveworld=1; ;;
+      --update-mods) modupdate=1; ;;
+      --backup) arkBackupPreUpdate=true; ;;
+      --stagingdir=*) arkStagingDir="${arg#--stagingdir=}"; ;;
+      --downloadonly) downloadonly=1; ;;
+      --no-download) nodownload=1; ;;
+      *)
+        echo "Unrecognized option $arg"
+        echo "Try 'arkmanager -h' or 'arkmanager --help' for more information."
+        exit 1
+    esac
   done
 
   echo "$$" >"${arkserverroot}/.ark-update.lock.$$" 2>/dev/null

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -599,18 +599,39 @@ function isTheServerOnline(){
 # Check if anybody is connected to the server
 #
 function numPlayersConnected(){
-  perl -MSocket -e '
-    my $port = int($ARGV[0]);
-    socket(my $socket, PF_INET, SOCK_DGRAM, 0);
-    setsockopt($socket, SOL_SOCKET, SO_RCVTIMEO, pack("i4", 1, 0, 0, 0));
-    my $sockaddr = pack_sockaddr_in($port, inet_aton($ARGV[1]));
-    send($socket, "\xff\xff\xff\xffTSource Engine Query\x00", 0, $sockaddr);
-    my $data = "";
-    recv($socket, $data, 1400, 0) or (print "-1" and exit(1));
-    my ($servername, $mapname, $game, $fullname, $rest) = split(/\x00/, substr($data, 6), 5);
-    my $players = ord(substr($rest, 2, 1));
-    print "$players\n";
-    ' "$(getQueryPort)" "${ark_MultiHome:-127.0.0.1}"
+  if [ -n "$arkUsePlayerList" ]; then
+    perl -MSocket -e '
+      my $port = int($ARGV[0]);
+      socket(my $socket, PF_INET, SOCK_DGRAM, 0);
+      setsockopt($socket, SOL_SOCKET, SO_RCVTIMEO, pack("i4", 1, 0, 0, 0));
+      my $sockaddr = pack_sockaddr_in($port, inet_aton($ARGV[1]));
+      send($socket, "\xff\xff\xff\xff\x55\xff\xff\xff\xff", 0, $sockaddr);
+      my $data = "";
+      recv($socket, $data, 1400, 0) or (print "-1" and exit(1));
+      if (ord(substr($data, 4, 1)) == 0x41) {
+        my $chal = substr($data, 5);
+        send($socket, "\xff\xff\xff\xff\x55" . $chal, 0, $sockaddr);
+        $data = "";
+        recv($socket, $data, 1400, 0) or (print "-1" and exit(1));
+      }
+      ord(substr($data, 4, 1)) != 0x44 and (print "-1" and exit(1));
+      my $players = ord(substr($data, 5, 1));
+      print "$players\n";
+      ' "$(getQueryPort)" "${ark_MultiHome:-127.0.0.1}"
+  else
+    perl -MSocket -e '
+      my $port = int($ARGV[0]);
+      socket(my $socket, PF_INET, SOCK_DGRAM, 0);
+      setsockopt($socket, SOL_SOCKET, SO_RCVTIMEO, pack("i4", 1, 0, 0, 0));
+      my $sockaddr = pack_sockaddr_in($port, inet_aton($ARGV[1]));
+      send($socket, "\xff\xff\xff\xffTSource Engine Query\x00", 0, $sockaddr);
+      my $data = "";
+      recv($socket, $data, 1400, 0) or (print "-1" and exit(1));
+      my ($servername, $mapname, $game, $fullname, $rest) = split(/\x00/, substr($data, 6), 5);
+      my $players = ord(substr($rest, 2, 1));
+      print "$players\n";
+      ' "$(getQueryPort)" "${ark_MultiHome:-127.0.0.1}"
+  fi
 }
 
 #
@@ -2063,6 +2084,18 @@ printStatus(){
       my $maxplayers = ord(substr($rest, 3, 1));
       print "Server Name: $servername\n";
       print "Players: $players / $maxplayers\n";
+      send($socket, "\xff\xff\xff\xff\x55\xff\xff\xff\xff", 0, $sockaddr);
+      $data = "";
+      recv($socket, $data, 1400, 0) or (print "Challenge request failed" and exit(1));
+      if (ord(substr($data, 4, 1)) == 0x41) {
+        my $chal = substr($data, 5);
+        send($socket, "\xff\xff\xff\xff\x55" . $chal, 0, $sockaddr);
+        $data = "";
+        recv($socket, $data, 1400, 0) or (print "A2S_PLAYERS request failed" and exit(1));
+      }
+      ord(substr($data, 4, 1)) != 0x44 and (print ("A2S_PLAYERS Response: : " . unpack("H*", $data)) and exit(1));
+      my $players = ord(substr($data, 5, 1));
+      print "Active Players: $players\n";
       ' "$(getQueryPort)" "${ark_MultiHome:-127.0.0.1}"
 
     if isTheServerOnline; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -10,6 +10,7 @@
 arkstVersion='1.6-pre3'
 arkstTag=''
 arkstCommit=''
+arkstGithubRepo="FezVrasta/ark-server-tools"
 
 doUpgradeTools() {
   local sudo=sudo
@@ -43,7 +44,7 @@ doUpgradeToolsFromCommit(){
   if [ -z "$tmpdir" ]; then echo "Unable to create temporary directory"; exit 1; fi
   cd "$tmpdir"
   echo "Downloading installer"
-  curl -L "https://github.com/FezVrasta/ark-server-tools/archive/${commit}.tar.gz" | tar -xz
+  curl -L "https://github.com/${arkstGithubRepo}/archive/${commit}.tar.gz" | tar -xz
   cd "ark-server-tools-${commit}/tools"
   if [ ! -f "install.sh" ]; then echo "install.sh not found in $PWD"; exit 1; fi
   sed -i -e "s|^arkstCommit='.*'|arkstCommit='${commit}'|" \
@@ -65,14 +66,14 @@ doUpgradeToolsFromCommit(){
 }
 
 doUpgradeToolsFromBranch(){
-  arkstLatestVersion=`curl -s "https://raw.githubusercontent.com/FezVrasta/ark-server-tools/${arkstChannel}/.version"`
-  arkstLatestCommit=`curl -s "https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads/${arkstChannel}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`
+  arkstLatestVersion=`curl -s "https://raw.githubusercontent.com/${arkstGithubRepo}/${arkstChannel}/.version"`
+  arkstLatestCommit=`curl -s "https://api.github.com/repos/${arkstGithubRepo}/git/refs/heads/${arkstChannel}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p'`
 
   if [ "$arkstLatestVersion" == "Not Found" ]; then
     echo "Channel ${arkstChannel} does not exist"
     echo
     echo "Available channels:"
-    curl -s https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/heads | sed -n 's|^ *"ref": "refs/heads/\(.*\)",|\1|p'
+    curl -s "https://api.github.com/repos/${arkstGithubRepo}/git/refs/heads" | sed -n 's|^ *"ref": "refs/heads/\(.*\)",|\1|p'
     echo
     return
   fi
@@ -105,7 +106,7 @@ doUpgradeToolsFromRelease(){
       tag_name) tagname="${v}"; ;;
       body) desc="${v}"
     esac
-  done < <(curl -s "https://api.github.com/repos/FezVrasta/ark-server-tools/releases/latest" | sed -n 's/^  "\([^"]*\)": "*\([^"]*\)"*,*/\1\t\2/p')
+  done < <(curl -s "https://api.github.com/repos/${arkstGithubRepo}/releases/latest" | sed -n 's/^  "\([^"]*\)": "*\([^"]*\)"*,*/\1\t\2/p')
 
   if [ -n "$tagname" ]; then
     if [ "$tagname" != "$arkstTag" ]; then
@@ -115,7 +116,7 @@ doUpgradeToolsFromRelease(){
       echo
       if [[ "$REPLY" =~ ^[Yy]$ ]]; then
         echo "Getting commit for latest release..."
-        local commit="$(curl -s "https://api.github.com/repos/FezVrasta/ark-server-tools/git/refs/tags/${tagname}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p')"
+        local commit="$(curl -s "https://api.github.com/repos/${arkstGithubRepo}/git/refs/tags/${tagname}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p')"
         doUpgradeToolsFromCommit "$commit"
       fi
     else

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1001,7 +1001,7 @@ printWarnMessage(){
       if [ -z "$reason" ]; then
         reason="$warnreason"
       fi
-    if [ "$1" == "update" ]; then
+    elif [ "$1" == "update" ]; then
       if [ -n "$appupdate" ]; then
         if [ -n "$modupdate" ]; then
           if [ -n "$msgReasonUpdateAppMod" ]; then

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -202,6 +202,7 @@ checkConfig() {
   # SavedArks directory
   if [ -n "$arkserverroot" ]; then
     local savedarksdir="${arkserverroot}/ShooterGame/Saved/${ark_AltSaveDirectoryName:-SavedArks}"
+    mkdir -p "${savedarksdir}"
     if [ ! -w "${savedarksdir}" ]; then
       echo -e "[" "$RED" "ERROR" "$NORMAL" "]" "\tThe ARK SavedArks directory is not writable, and saveworld will fail"
     fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -2662,7 +2662,7 @@ main(){
           echo "Release Tag: ${arkstTag}"
         fi
         blobsize="$(sed "s@^arkst\\(Commit\\|Tag\\)=.*@\\1=''@" "$0" | wc -c)"
-        echo "Blob SHA: $( (echo -ne "blob ${blobsize}\0"; sed "s@^arkst\\(Commit\\|Tag\\)=.*@\\1=''@" "$0") | sha1sum | cut -d' ' -f1)"
+        echo "Blob SHA: $( (echo -ne "blob ${blobsize}\0"; sed "s@^\\(arkst\\(Commit\\|Tag\\)\\)=.*@\\1=''@" "$0") | sha1sum | cut -d' ' -f1)"
         exit 1
       ;;
       -h|--help)

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1166,6 +1166,7 @@ doUpdate() {
   local modupdate=
   local saveworld=
   local downloadonly=
+  local nodownload=
 
   for arg in "$@"; do
     if [ "$arg" == "--force" ]; then
@@ -1189,6 +1190,8 @@ doUpdate() {
       arkStagingDir="${ark#--stagingdir=}"
     elif [ "$arg" == "--downloadonly" ]; then
       downloadonly=1
+    elif [ "$arg" == "--no-download" ]; then
+      nodownload=1
     else
       echo "Unrecognized option $arg"
       echo "Try 'arkmanager -h' or 'arkmanager --help' for more information."
@@ -1213,8 +1216,10 @@ doUpdate() {
   rm -f "${arkserverroot}/.ark-update.lock.$$"
 
   if [ -n "$modupdate" ]; then
-    if ! doDownloadAllMods; then
-      modupdate=
+    if [ -z "$nodownload" ]; then
+      if ! doDownloadAllMods; then
+        modupdate=
+      fi
     fi
     if ! isAnyModUpdateNeeded; then
       modupdate=
@@ -1244,12 +1249,14 @@ doUpdate() {
         rm -rf "$arkStagingDir/ShooterGame/Saved/"*
       fi
 
-      echo -n "Downloading ARK update"
-      cd "$steamcmdroot"
-      runSteamCMDAppUpdate "$arkStagingDir" $validate
-      if [ -d "${arkStagingDir}/steamapps/downloading/${appid}" ]; then
-        echo "Update download interrupted"
-        return 1
+      if [ -z "$nodownload" ]; then
+        echo -n "Downloading ARK update"
+        cd "$steamcmdroot"
+        runSteamCMDAppUpdate "$arkStagingDir" $validate
+        if [ -d "${arkStagingDir}/steamapps/downloading/${appid}" ]; then
+          echo "Update download interrupted"
+          return 1
+        fi
       fi
     fi
   fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -2114,254 +2114,263 @@ showUsage() {
 # Main program
 #---------------------
 
-# check the configuration and throw errors or warnings if needed
-checkConfig
+main(){
+  # check the configuration and throw errors or warnings if needed
+  checkConfig
 
-while true; do
-  options=( )
-  allinstances=no
-  instances=( )
-  args=( )
-  command="$1"
-  shift
-  nrarg=0
+  while true; do
+    options=( )
+    allinstances=no
+    instances=( )
+    args=( )
+    command="$1"
+    shift
+    nrarg=0
 
-  # Handle global options
-  case "$command" in
-    --verbose)
-      verbose=1
-      continue
-    ;;
-    --dots)
-      progressDisplayType=dots
-      continue
-    ;;
-    --spinner)
-      progressDisplayType=spinner
-      continue
-    ;;
-    --cronjob)
-      inCronJob=true
-      continue
-    ;;
-  esac
-
-  # get the number of arguments for commands that take arguments
-  case "$command" in
-    installmod) nrarg=1; ;;
-    uninstallmod) nrarg=1; ;;
-    reinstallmod) nrarg=1; ;;
-    broadcast) nrarg=1; ;;
-    rconcmd) nrarg=1; ;;
-    useconfig) nrarg=1; ;;
-    install-cronjob) nrarg=1; ;;
-    remove-cronjob) nrarg=1; ;;
-    remove-mods) nrarg=1; ;;
-  esac
-
-  # Enumerate the options and arguments
-  while [ $# -ne 0 ]; do
-    case "$1" in
-      --)
-        shift
-        break
-      ;;
-      --args)
-        nrarg=$#
-      ;;
+    # Handle global options
+    case "$command" in
       --verbose)
         verbose=1
+        continue
       ;;
       --dots)
         progressDisplayType=dots
+        continue
       ;;
       --spinner)
         progressDisplayType=spinner
+        continue
       ;;
-      --*)
-        options+=( "$1" )
+      --cronjob)
+        inCronJob=true
+        continue
       ;;
-      @all)
-        allinstances=yes
-      ;;
-      @*)
-        instances+=( "${1#@}" )
-      ;;
-      *)
-        if [ $nrarg -gt 0 ]; then
-          args+=( "$1" )
-	  (( nrarg-- ))
-        else
+    esac
+
+    # get the number of arguments for commands that take arguments
+    case "$command" in
+      installmod) nrarg=1; ;;
+      uninstallmod) nrarg=1; ;;
+      reinstallmod) nrarg=1; ;;
+      broadcast) nrarg=1; ;;
+      rconcmd) nrarg=1; ;;
+      useconfig) nrarg=1; ;;
+      install-cronjob) nrarg=1; ;;
+      remove-cronjob) nrarg=1; ;;
+      remove-mods) nrarg=1; ;;
+    esac
+
+    # Enumerate the options and arguments
+    while [ $# -ne 0 ]; do
+      case "$1" in
+        --)
+          shift
           break
+        ;;
+        --args)
+          nrarg=$#
+        ;;
+        --verbose)
+          verbose=1
+        ;;
+        --dots)
+          progressDisplayType=dots
+        ;;
+        --spinner)
+          progressDisplayType=spinner
+        ;;
+        --*)
+          options+=( "$1" )
+        ;;
+        @all)
+          allinstances=yes
+        ;;
+        @*)
+          instances+=( "${1#@}" )
+        ;;
+        *)
+          if [ $nrarg -gt 0 ]; then
+            args+=( "$1" )
+            (( nrarg-- ))
+          else
+            break
+          fi
+        ;;
+      esac
+      shift
+    done
+
+    # handle non-instance separately
+    case "$command" in
+      upgrade-tools)
+        doUpgradeTools
+        exit
+      ;;
+      uninstall-tools)
+        doUninstallTools
+        exit
+      ;;
+      useconfig)
+        defaultinstance="${args[0]}"
+        continue
+      ;;
+      remove-mods)
+        doRemoveMods "${args[0]}"
+        if [ $# -eq 0 ]; then
+          exit 0
+        else
+          continue
         fi
       ;;
-    esac
-    shift
-  done
-
-  # handle non-instance separately
-  case "$command" in
-    upgrade-tools)
-      doUpgradeTools
-      exit
-    ;;
-    uninstall-tools)
-      doUninstallTools
-      exit
-    ;;
-    useconfig)
-      defaultinstance="${args[0]}"
-      continue
-    ;;
-    remove-mods)
-      doRemoveMods "${args[0]}"
-      if [ $# -eq 0 ]; then
-        exit 0
-      else
-        continue
-      fi
-    ;;
-    list-instances)
-      doListAllInstances "${options[@]}"
-      exit
-    ;;
-    --version)
-      echo "Version: ${arkstVersion}"
-      echo "Channel: ${arkstChannel}"
-      if [ -n "${arkstCommit}" ]; then
-        echo "Commit: ${arkstCommit:0:7}"
-      fi
-      blobsize="$(sed "s@^arkstCommit=.*@arkstCommit=''@" "$0" | wc -c)"
-      echo "Blob SHA: $( (echo -ne "blob ${blobsize}\0"; sed "s@^arkstCommit=.*@arkstCommit=''@" "$0") | sha1sum | cut -d' ' -f1)"
-      exit 1
-    ;;
-    -h|--help)
-      showUsage
-      exit 1
-    ;;
-    "")
-      echo "arkmanager v${arkstVersion}: no command specified"
-      showUsage
-      exit 1
-    ;;
-  esac
-
-  # Handle no instances being specified
-  if [[ "${#instances[@]}" == 0 && "$allinstances" == "no" ]]; then
-    if [ -n "$defaultinstance" ]; then
-      instances=( "$defaultinstance" )
-    else
-      echo "No instances supplied for command ${command} ${options[*]} ${args[*]}"
-      read -p "Do you wish to run this command for all instances?" -n 1 -r
-      echo
-      if [[ "$REPLY" =~ ^[Yy]$ ]]; then
-        allinstances=yes
-      else
+      list-instances)
+        doListAllInstances "${options[@]}"
+        exit
+      ;;
+      --version)
+        echo "Version: ${arkstVersion}"
+        echo "Channel: ${arkstChannel}"
+        if [ -n "${arkstCommit}" ]; then
+          echo "Commit: ${arkstCommit:0:7}"
+        fi
+        blobsize="$(sed "s@^arkstCommit=.*@arkstCommit=''@" "$0" | wc -c)"
+        echo "Blob SHA: $( (echo -ne "blob ${blobsize}\0"; sed "s@^arkstCommit=.*@arkstCommit=''@" "$0") | sha1sum | cut -d' ' -f1)"
         exit 1
+      ;;
+      -h|--help)
+        showUsage
+        exit 1
+      ;;
+      "")
+        echo "arkmanager v${arkstVersion}: no command specified"
+        showUsage
+        exit 1
+      ;;
+    esac
+
+    # Handle no instances being specified
+    if [[ "${#instances[@]}" == 0 && "$allinstances" == "no" ]]; then
+      if [ -n "$defaultinstance" ]; then
+        instances=( "$defaultinstance" )
+      else
+        echo "No instances supplied for command ${command} ${options[*]} ${args[*]}"
+        read -p "Do you wish to run this command for all instances?" -n 1 -r
+        echo
+        if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+          allinstances=yes
+        else
+          exit 1
+        fi
       fi
     fi
-  fi
 
-  # Handle all instances being requested
-  if [[ "$allinstances" == "yes" ]]; then
-    instances=( $(getAllInstanceNames) )
-  fi
+    # Handle all instances being requested
+    if [[ "$allinstances" == "yes" ]]; then
+      instances=( $(getAllInstanceNames) )
+    fi
 
-  # Run the command for each instance requested
-  for instance in "${instances[@]}"; do
-  (
-    echo "Running command '${command}' for instance '${instance}'"
-    useConfig "$instance"
-    checkConfig
-
-    case "$command" in
-      run)
-        doRun
-      ;;
-      start)
-        doStart "${options[@]}"
-      ;;
-      stop)
-        doStop shutdown "${options[@]}"
-      ;;
-      restart)
-        doStop restart "${options[@]}"
-        echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
-      ;;
-      cancelshutdown)
-        doCancelShutdown "${options[@]}"
-      ;;
-      install)
-        doInstall
-      ;;
-      update)
-        doUpdate "${options[@]}"
-      ;;
-      checkupdate)
-        checkForUpdate
-      ;;
-      installmod)
-        doInstallMod "${args[@]}"
-      ;;
-      uninstallmod)
-        doUninstallMod "${args[@]}"
-      ;;
-      reinstallmod)
-        doUninstallMod "${args[@]}"
-        doInstallMod "${args[@]}"
-      ;;
-      backup)
-        doBackup
-      ;;
-      broadcast)
-        doBroadcast "${args[@]}"
-      ;;
-      saveworld)
-        doSaveWorld
-      ;;
-      rconcmd)
-        rconcmd "${args[@]}"
-      ;;
-      status)
-        printStatus
-      ;;
-      install-cronjob)
-        doInstallCronJob "${args[@]}" "${options[@]}"
-      ;;
-      remove-cronjob)
-        doRemoveCronJob "${args[@]}"
-      ;;
-      *)
-        echo -n "arkmanager v${arkstVersion}: unknown command '$command' specified"
-        showUsage
-        exit 255
-      ;;
-    esac
-  )
-  laststatus=$?
-  if [ $laststatus -eq 255 ]; then
-    exit 1
-  elif [ $laststatus -ne 0 ]; then
-    status=$laststatus
-  fi
-  done
-
-  # Perform the restart portion of the restart command
-  if [[ "$command" == "restart" ]]; then
-    sleep 1
+    # Run the command for each instance requested
     for instance in "${instances[@]}"; do
     (
+      echo "Running command '${command}' for instance '${instance}'"
       useConfig "$instance"
-      doStart "${options[@]}"
-      echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
-      echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"
+      checkConfig
+
+      case "$command" in
+        run)
+          doRun
+        ;;
+        start)
+          doStart "${options[@]}"
+        ;;
+        stop)
+          doStop shutdown "${options[@]}"
+        ;;
+        restart)
+          doStop restart "${options[@]}"
+          echo "`timestamp`: stop" >> "$logdir/$arkmanagerLog"
+        ;;
+        cancelshutdown)
+          doCancelShutdown "${options[@]}"
+        ;;
+        install)
+          doInstall
+        ;;
+        update)
+          doUpdate "${options[@]}"
+        ;;
+        checkupdate)
+          checkForUpdate
+        ;;
+        installmod)
+          doInstallMod "${args[@]}"
+        ;;
+        uninstallmod)
+          doUninstallMod "${args[@]}"
+        ;;
+        reinstallmod)
+          doUninstallMod "${args[@]}"
+          doInstallMod "${args[@]}"
+        ;;
+        backup)
+          doBackup
+        ;;
+        broadcast)
+          doBroadcast "${args[@]}"
+        ;;
+        saveworld)
+          doSaveWorld
+        ;;
+        rconcmd)
+          rconcmd "${args[@]}"
+        ;;
+        status)
+          printStatus
+        ;;
+        install-cronjob)
+          doInstallCronJob "${args[@]}" "${options[@]}"
+        ;;
+        remove-cronjob)
+          doRemoveCronJob "${args[@]}"
+        ;;
+        *)
+          echo -n "arkmanager v${arkstVersion}: unknown command '$command' specified"
+          showUsage
+          exit 255
+        ;;
+      esac
     )
+    laststatus=$?
+    if [ $laststatus -eq 255 ]; then
+      exit 1
+    elif [ $laststatus -ne 0 ]; then
+      status=$laststatus
+    fi
     done
-  fi
 
-  if [ $# -eq 0 ]; then
-    break
-  fi
-done
+    # Perform the restart portion of the restart command
+    if [[ "$command" == "restart" ]]; then
+      sleep 1
+      for instance in "${instances[@]}"; do
+      (
+        useConfig "$instance"
+        doStart "${options[@]}"
+        echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
+        echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"
+      )
+      done
+    fi
 
-exit $status
+    if [ $# -eq 0 ]; then
+      break
+    fi
+  done
+
+  exit $status
+}
+
+# Only execute main function if script is not being sourced
+# by another script
+if [[ "$(caller)" =~ ^0 ]]; then
+  main "$@"
+fi
+

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -660,6 +660,22 @@ doRun() {
 
   arkserveropts="$serverMap"
 
+  while read varname; do
+    val="${!varname}"
+    modid="${varname#arkmod_}"
+    case "$val" in
+      game*|enabled)
+        ark_GameModIds="${ark_GameModIds}${ark_GameModIds:+,}${modid}"
+        ;;
+      map*)
+        serverMapModId="${modid}"
+        ;;
+      tc|total*)
+        ark_TotalConversionMod="${modid}"
+        ;;
+    esac
+  done < <(sed -n 's/^\(arkmod_[^= ]*\)=.*/\1/p' <"$configfile")
+
   if [ -n "$serverMapModId" ]; then
     serverMap="$(perl -e '
       my $data;
@@ -1488,6 +1504,11 @@ getModIds(){
     echo "${serverMapModId}"
     echo "${ark_TotalConversionMod}"
     echo "${ark_GameModIds}" | tr ',' '\n'
+    for v in "${!arkmod_@}"; do
+      if [ "${!v}" != "disabled" ]; then
+        echo "${v#arkmod_}"
+      fi
+    done
     find "${arkserverroot}/ShooterGame/Content/Mods" -maxdepth 1 -type d -printf "%P\n"
   ) | sort | uniq | grep '^[1-9][0-9]*$'
 }

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -7,7 +7,7 @@
 # Contributors:         Sispheor, Atriusftw, klightspeed, lexat, puseidr
 
 # Script version
-arkstVersion='1.6-pre1'
+arkstVersion='1.6-pre3'
 arkstTag=''
 arkstCommit=''
 

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -881,12 +881,14 @@ doStart() {
     local updatepid="$(<"${arkserverroot}/.ark-update.lock")"
     if kill -0 "$updatepid" >/dev/null 2>&1; then
       echo "An update is currently in progress.  Start aborted"
+      echo "`timestamp`: Start aborted due to running update - pid: $updatepid" >>"$logdir/$arkserverLog"
       return 1
     fi
   fi
 
   if isTheServerRunning; then
     echo "The server is already running"
+    echo "`timestamp`: Start aborted due to server already running"
   else
     if [ "$arkAutoUpdateOnStart" == "true" ]; then
       if ! [[ " $* " =~ " --noautoupdate " ]]; then
@@ -969,7 +971,7 @@ doStop() {
     fi
     tput sc
     echo "Stopping server..."
-    echo "`timestamp`: stopping" >> "$logdir/$arkmanagerLog"
+    echo "`timestamp`: stopping; reason: $stopreason" >> "$logdir/$arkmanagerLog"
     rm -f "$arkserverroot/$arkautorestartfile"
     # kill the server with the PID
     PID=`getServerPID`
@@ -1364,6 +1366,12 @@ doUpdate() {
     esac
   done
 
+  # check if the server was alive before the update so we can launch it back after the update
+  serverWasAlive=0
+  if isTheServerRunning ;then
+    serverWasAlive=1
+  fi
+
   echo "$$" >"${arkserverroot}/.ark-update.lock.$$" 2>/dev/null
   while true; do
     if ! ln "${arkserverroot}/.ark-update.lock.$$" "${arkserverroot}/.ark-update.lock" 2>/dev/null; then
@@ -1379,6 +1387,8 @@ doUpdate() {
     fi
   done
   rm -f "${arkserverroot}/.ark-update.lock.$$"
+
+  echo "`timestamp`: checking for update; PID: $$"
 
   if [ -n "$modupdate" ]; then
     if [ -z "$nodownload" ]; then
@@ -1461,12 +1471,6 @@ doUpdate() {
       fi
     fi
 
-    # check if the server was alive before the update so we can launch it back after the update
-    serverWasAlive=0
-    if isTheServerRunning ;then
-      serverWasAlive=1
-    fi
-
     if [ -n "$saveworld" ]; then
       echo "Saving world"
       doSaveWorld
@@ -1525,20 +1529,21 @@ doUpdate() {
         fi
       done
     fi
-
-    rm -f "${arkserverroot}/.ark-update.lock"
-    # we restart the server only if it was started before the update
-    if [ $serverWasAlive -eq 1 ] || [ -f "${arkserverroot}/.startAfterUpdate" ]; then
-      rm -f "${arkserverroot}/.startAfterUpdate"
-      rm -f "${arkserverroot}/.ark-update.lock"
-      doStart --noautoupdate
-    fi
   else
     echo "Your server is already up to date! The most recent version is ${bnumber}."
     echo "`timestamp`: No update needed." >> "$logdir/update.log"
   fi;
 
   rm -f "${arkserverroot}/.ark-update.lock"
+
+  if ! isTheServerRunning; then
+    # we restart the server only if it was started before the update
+    if [ $serverWasAlive -eq 1 ] || [ -f "${arkserverroot}/.startAfterUpdate" ]; then
+      rm -f "${arkserverroot}/.startAfterUpdate"
+      rm -f "${arkserverroot}/.ark-update.lock"
+      doStart --noautoupdate
+    fi
+  fi
 }
 
 #
@@ -2642,10 +2647,9 @@ main(){
       sleep 1
       for instance in "${instances[@]}"; do
       (
+        echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"
         useConfig "$instance"
         doStart "${options[@]}"
-        echo "`timestamp`: start" >> "$logdir/$arkmanagerLog"
-        echo "`timestamp`: restart" >> "$logdir/$arkmanagerLog"
       )
       done
     fi

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -1428,16 +1428,16 @@ doUpdate() {
           cp -al "$arkserverroot/ShooterGame/." "$arkStagingDir/ShooterGame"
           cp -al "$arkserverroot/Engine/." "$arkStagingDir/Engine"
           cp -al "$arkserverroot/linux64/." "$arkStagingDir/linux64"
-          cp -al "$arkserverroot/PackageInfo.bin" "$arkStagingDir/PackageInfo.bin"
-          cp -al "$arkserverroot/steamclient.so" "$arkStagingDir/steamclient.so"
-          cp -al "$arkserverroot/version.txt" "$arkStagingDir/version.txt"
           cp -a "$arkserverroot/steamapps/." "$arkStagingDir/steamapps"
+	  cp -l "$arkserverroot/"* "$arkStagingDir"
         else
           rsync -a "$arkserverroot/." "$arkStagingDir/."
         fi
         rm -rf "$arkStagingDir/ShooterGame/Content/Mods/"*
         rm -rf "$arkStagingDir/ShooterGame/Saved/"*
         rm -rf "$arkStagingDir/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamapps"
+	cp -al "$arkserverroot/ShooterGame/Content/Mods/111111111/." "$arkStagingDir/ShooterGame/Content/Mods/111111111"
+	cp -l "$arkserverroot/ShooterGame/Content/Mods/111111111.mod" "$arkStagingDir/ShooterGame/Content/Mods/111111111.mod"
       fi
 
       if [ -z "$nodownload" ]; then
@@ -1469,7 +1469,12 @@ doUpdate() {
     fi
     echo "Not applying update - download-only enabled"
   elif [ -n "$appupdate" -o -n "$modupdate" -o -n "$bgupdate" ]; then
-    arkversion="$(<"$arkserverroot/version.txt")"
+    if [ -f "$arkserverroot/version.txt" ]; then
+      arkversion="$(<"$arkserverroot/version.txt")"
+    else
+      arkversion="$(getCurrentVersion; echo "$instver")"
+    fi
+
     if isTheServerRunning; then
       if [ "$updatetype" == "safe" ]; then
         while [ ! `find $arkserverroot/ShooterGame/Saved/SavedArks -mmin -1 -name ${serverMap##*/}.ark` ]; do
@@ -1510,9 +1515,7 @@ doUpdate() {
           cp -alu --remove-destination "$arkStagingDir/ShooterGame/." "$arkserverroot/ShooterGame"
           cp -alu --remove-destination "$arkStagingDir/Engine/." "$arkserverroot/Engine"
           cp -alu --remove-destination "$arkStagingDir/linux64/." "$arkserverroot/linux64"
-          cp -alu --remove-destination "$arkStagingDir/PackageInfo.bin" "$arkserverroot/PackageInfo.bin"
-          cp -alu --remove-destination "$arkStagingDir/steamclient.so" "$arkserverroot/steamclient.so"
-          cp -alu --remove-destination "$arkStagingDir/version.txt" "$arkserverroot/version.txt"
+	  cp -lu --remove-destination "$arkStagingDir/"* "$arkserverroot"
           cp -au --remove-destination "$arkStagingDir/steamapps/." "$arkserverroot/steamapps"
         else
           rsync -a "$arkStagingDir/." "$arkserverroot"
@@ -2299,7 +2302,9 @@ printStatus(){
 
   getCurrentVersion
   echo -e "$NORMAL" "Server build ID: " "$GREEN" $instver "$NORMAL"
-  echo -e "$NORMAL" "Server version: " "$GREEN" "$(<"$arkserverroot/version.txt")" "$NORMAL"
+  if [ -f "$arkserverroot/version.txt" ]; then
+    echo -e "$NORMAL" "Server version: " "$GREEN" "$(<"$arkserverroot/version.txt")" "$NORMAL"
+  fi
 }
 
 getAllInstanceNames(){

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -656,7 +656,8 @@ doRun() {
     exit 1
   fi
   
-  echo "$$" >"${arkserverroot}/${arkmanagerpidfile}"
+  # $$ returns the main process, $BASHPID returns the current process
+  echo "$BASHPID" >"${arkserverroot}/${arkmanagerpidfile}"
 
   if [ -f "${arkserverroot}/.ark-update.lock" ]; then
     local updatepid="$(<"${arkserverroot}/.ark-update.lock")"

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -607,7 +607,7 @@ function numPlayersConnected(){
 # run function
 #
 doRun() {
-  cd "$arkserverroot"
+  cd "${arkserverroot}/${arkserverexec%/*}"
 
   arkserveropts="$serverMap"
 
@@ -702,6 +702,14 @@ doRun() {
       arkextraopts=( "${arkextraopts[@]}" "-${name}=${val}" )
     fi
   done
+
+  if [[ " ${arkextraopts[*]} " =~ " -automanagedmods " ]]; then
+    if [ ! -f "${arkserverroot}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamcmd.sh" ]; then
+      mkdir -p "${arkserverroot}/Engine/Binaries/ThirdParty/SteamCMD/Linux"
+      curl -s "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" -o "${arkserverroot}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamcmd_linux.tar.gz"
+      tar -xzf "${arkserverroot}/Engine/Binaries/ThirdParty/SteamCMD/Linux/steamcmd_linux.tar.gz" -C "${arkserverroot}/Engine/Binaries/ThirdParty/SteamCMD/Linux"
+    fi
+  fi
 
   arkserveropts="${arkserveropts}?listen"
   # run the server in background

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -742,6 +742,9 @@ doRun() {
     # Disable auto-restart so we don't get caught in a restart loop
     rm -f "$arkserverroot/$arkautorestartfile"
     restartserver=0
+    if [ -n "$arkAlwaysRestartOnCrash" ]; then
+      restartserver=1
+    fi
 
     sleep 5
 
@@ -762,6 +765,8 @@ doRun() {
         echo "`timestamp`: Bad PID '$pid'; expected '$serverpid'"
         if [ "$pid" != "" ]; then
 	  # Another instance must be running - disable autorestart
+	  echo "Error: another server instance is running from the same directory"
+	  echo "Aborting - two servers MUST NOT run from the same directory"
 	  restartserver=0
 	fi
 	break
@@ -796,6 +801,10 @@ doStart() {
         echo "Updating server"
         doUpdate --update-mods
       fi
+    fi
+
+    if [[ " $* " =~ " --alwaysrestart " ]]; then
+      arkAlwaysRestartOnCrash=true
     fi
     tput sc
     echo "The server is starting..."

--- a/tools/arkmanager.cfg
+++ b/tools/arkmanager.cfg
@@ -32,6 +32,10 @@ msgWarnRestartMinutes="This ARK server will shutdown for a restart in %d minutes
 msgWarnRestartSeconds="This ARK server will shutdown for a restart in %d seconds"
 msgWarnShutdownMinutes="This ARK server will shutdown in %d minutes"
 msgWarnShutdownSeconds="This ARK server will shutdown in %d seconds"
+msgWarnCancelled="Restart cancelled by player request"
+
+# Restart cancel chat command
+#chatCommandRestartCancel="/cancelupdate"
 
 # ARK server common options - use ark_<optionname>=<value>
 # comment out these values if you want to define them

--- a/tools/systemd/arkmanager.service
+++ b/tools/systemd/arkmanager.service
@@ -6,6 +6,7 @@ After=network.target
 ExecStart=/usr/libexec/arkmanager/arkmanager.init start
 ExecStop=/usr/libexec/arkmanager/arkmanager.init stop
 Type=forking
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/tools/systemd/arkmanager.service
+++ b/tools/systemd/arkmanager.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 ExecStart=/usr/libexec/arkmanager/arkmanager.init start
 ExecStop=/usr/libexec/arkmanager/arkmanager.init stop
-Type=oneshot
+Type=forking
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes backported to 1.5:
* Use `serverMapModId` to set map name and `MapModID` option
* Return `-1` from `numplayers` if server unreachable
* Fix a couple of potential issues with player count checking
* Fix an inconsistency between `install.sh` and `arkmanager.init`
* ` \n ` added to empty response message
* Fix update `--force` with `arkStagingDir`
* Fix `--stagingdir=` parameter
* Change systemd service type to forking
* Add `RemainAfterExit=yes` to `arkmanager.service`
* Create the saved arks directory if it doesn't exist
* Default non-privileged instance-config path
* Exclude Primitive+ from mod download and extraction
* Prevent server start during update
* Fix interaction between start and update
* Fix error typo
* Fix double-start when auto-update is enabled
* Restart the server if it was updated while running
* Touch app manifest on update
* Suffix autostart and autorestart with instance name
* Add `.arktributetribe` files to backup

New features in 1.6:
* Change `.mod` file output
* Use name from `mod.info` if mod name can't be retrieved
* Add Blob SHA to `--version` output
* Add handling for global options
* Add support for adding and removing cron jobs
* Process ark options in config file order
* Fix `numPlayersConnected` to use `getQueryPort`
* Handle multiple map files in mods
* Account for all lower-case names in some environments
* Parse output of `download_workshop_item` command
* Improve broadcast warning messages
* Allow stop and restart commands to take a reason
* Move `.modbranch` to `__arkmanager_modbranch__.info`
* Remove now unnecessary ulimit setup
* Fix typo in `doBackup`
* Change to the home directory
* Add `cancelshutdown` command
* Print SteamCMD command being executed
* Allow `{time}` in warning reason
* Add `remove-mods` command - removes mods from workshop directory
* Fix mod download not being retried
* Add `--no-download` option to update
* Clean up after SteamCMD if it returns successful
* Make `arkmanager` script sourceable
* Fix update `--force` with `arkStagingDir`
* Fix `--stagingdir=` parameter
* Add option to allow players to cancel restart
* Add support for `-automanagedmods`
* Change systemd service type to forking
* Add option to always auto-restart
* Add `RemainAfterExit=yes` to `arkmanager.service`
* Create the saved arks directory if it doesn't exist
* Add `printconfig` command
* Change config migration
* Improve restart behaviour using pid files
* Add `--warnreason`
* Stop warning if server is offline
* Use the `A2S_PLAYER` query to get active players
* Get version from `version.txt`
* Add `installmods` command
* Add support for `arkmod_*` in config
* Add `enablemod` and `disablemod` commands
* Add `arkPriorityBoost`
* Fix `doRun` writing the wrong PID to the run file
* Use full `yyyy-mm-dd HH:MM:SS` timestamp
* Restart server if necessary after update check
* Allow multiple mods to be installed or uninstalled
* Add `uninstallmods` command
* Sync more files; accept missing `version.txt`
* Don't use the old `ps -ef` method with `-clusterid`
* Add old PID file; remove PID files on stop
* Sync more files; accept missing `version.txt`
* Use release tags by default for lastest version