### PR TITLE
Update README.asciidoc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -590,7 +590,7 @@ Common ARK options
     Alternative directory under `ShooterGame/Saved` under which to
     save the world files
 
-`arkflag_UseBattlEye=true`::
-    Enables BattlEye
+`arkflag_NoBattlEye=true`::
+    Disables BattlEye
 
 


### PR DESCRIPTION
The Ark update at the end of December '16 turns BattlEye on by default and added the new -NoBattlEye flag that needs to be explicitly called to disable it. Due to the nature of how Ark Server Tools handles flags the only update needed to the code base is in documentation.