### PR TITLE
Workaround for the only-one-instance-restarts bug.

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -556,7 +556,6 @@ function checkForUpdate(){
 # Return 0 if update is needed, else return 1
 #
 function isUpdateNeeded(){
-  # instver="$(getCurrentVersion)"
   bnumber="$(getAvailableVersion)"
   if [[ -z "$bnumber" || "$bnumber" -eq "$instver" ]]; then
     return 1   # no update needed

--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -228,6 +228,8 @@ RED="\\033[1;31m"
 YELLOW="\\e[0;33m"
 NORMAL="\\033[0;39m"
 maxOpenFiles=100000
+instver="$(getCurrentVersion)" # Needed here to restart @all instaces after update.
+
 
 # Set TERM to "dumb" if TERM is not set
 export TERM=${TERM:-dumb}
@@ -554,7 +556,7 @@ function checkForUpdate(){
 # Return 0 if update is needed, else return 1
 #
 function isUpdateNeeded(){
-  instver="$(getCurrentVersion)"
+  # instver="$(getCurrentVersion)"
   bnumber="$(getAvailableVersion)"
   if [[ -z "$bnumber" || "$bnumber" -eq "$instver" ]]; then
     return 1   # no update needed


### PR DESCRIPTION
This is a small workaround which restarts all instances, on "@all"-paramter, if an update is necessary.

Resolved issues: #796