### PR TITLE
Delay until instance starts.

### DIFF
--- a/tools/arkmanager
+++ b/tools/arkmanager
@@ -3434,6 +3434,20 @@ main(){
         ;;
         start)
           doStart "${options[@]}"
+	  if [[ ${#instances[@]} > 1 ]]; then
+          	COUNTER=0
+                if [ -z "$defaultinstance_max" ]; then
+                      defaultinstance_max=0
+                fi
+                while [  $COUNTER -lt $defaultinstance_max ]; do
+                        echo -ne "$NORMAL Waiting up to $RED$((defaultinstance_max-COUNTER))$NORMAL seconds before starting next instance."\\r
+                     let COUNTER=COUNTER+1
+                        if isTheServerOnline ;then
+                                break
+                        fi
+                     sleep 1s
+                done
+          fi
         ;;
         stop)
           doStop shutdown "${options[@]}"


### PR DESCRIPTION
This will delay up to a set amount of time before starting the rest of the instances if defaultinstance_max is defined in the arkmanager.cfg file. Setting the value to 0 will cause no delay or not setting a value will cause no delay.